### PR TITLE
multi: check reputation at start of simulation to ensure worth running

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -960,6 +960,7 @@ dependencies = [
  "bitcoin",
  "clap",
  "csv",
+ "futures",
  "hex",
  "humantime",
  "ln-resource-mgr",

--- a/ln-resource-mgr/src/lib.rs
+++ b/ln-resource-mgr/src/lib.rs
@@ -232,6 +232,15 @@ pub mod reputation {
         }
     }
 
+    impl Display for ForwardResolution {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                ForwardResolution::Settled => write!(f, "settled"),
+                ForwardResolution::Failed => write!(f, "failed"),
+            }
+        }
+    }
+
     /// A unique identifier for a htlc on a channel (payment hash may be repeated for mpp payments).
     #[derive(PartialEq, Eq, Hash, Debug, Clone, Copy)]
     pub struct HtlcRef {

--- a/ln-simln-jamming/Cargo.toml
+++ b/ln-simln-jamming/Cargo.toml
@@ -21,3 +21,4 @@ csv = "1.3.1"
 hex = "0.4.3"
 clap = { version = "4.0", features = ["derive"] }
 humantime = "2.1.0"
+futures = "0.3.31"

--- a/ln-simln-jamming/src/parsing.rs
+++ b/ln-simln-jamming/src/parsing.rs
@@ -22,6 +22,12 @@ const DEFAULT_BOOTSTRAP_FILE: &str = "./bootstrap.csv";
 /// Default file used to imitate peacetime revenue
 const DEFAULT_PEACETIME_FILE: &str = "./no_attacker.csv";
 
+/// Default percent of good reputation pairs the target requires.
+const DEFAULT_TARGET_REP_PERCENT: &str = "50";
+
+/// Default percent of good reputation pairs with the target that the attacker requires.
+const DEFAULT_ATTACKER_REP_PERCENT: &str = "50";
+
 #[derive(Parser)]
 #[command(version, about)]
 pub struct Cli {
@@ -43,6 +49,38 @@ pub struct Cli {
     /// values (eg: 1w, 3d).
     #[arg(long, value_parser = parse_duration)]
     pub bootstrap_duration: Duration,
+
+    /// The minimum percentage of channel pairs between the target and its honest peers that the target needs to have
+    /// good reputation on for the simulation to run.
+    #[arg(long, default_value = DEFAULT_TARGET_REP_PERCENT)]
+    pub target_reputation_percent: u8,
+
+    /// The minimum percentage of pairs with between the target and the attacker that the attacker needs to have good
+    /// reputation on for the simulation to run.
+    #[arg(long, default_value = DEFAULT_ATTACKER_REP_PERCENT)]
+    pub attacker_reputation_percent: u8,
+}
+
+impl Cli {
+    pub fn validate(&self) -> Result<(), BoxError> {
+        if self.target_reputation_percent == 0 || self.target_reputation_percent > 100 {
+            return Err(format!(
+                "target reputation percent {} must be in (0;100]",
+                self.target_reputation_percent
+            )
+            .into());
+        }
+
+        if self.attacker_reputation_percent == 0 || self.attacker_reputation_percent > 100 {
+            return Err(format!(
+                "attacker reputation percent {} must be in (0;100]",
+                self.attacker_reputation_percent
+            )
+            .into());
+        }
+
+        Ok(())
+    }
 }
 
 fn parse_duration(s: &str) -> Result<Duration, String> {

--- a/ln-simln-jamming/src/reputation_interceptor.rs
+++ b/ln-simln-jamming/src/reputation_interceptor.rs
@@ -299,6 +299,14 @@ impl ReputationInterceptor {
         &self,
         resolved_htlc: HtlcResolve,
     ) -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
+        log::info!(
+            "Resolving htlc {}:{} on {} with outcome {}",
+            resolved_htlc.incoming_htlc.channel_id,
+            resolved_htlc.incoming_htlc.htlc_index,
+            resolved_htlc.outgoing_channel_id,
+            resolved_htlc.forward_resolution,
+        );
+
         match self
             .network_nodes
             .lock()

--- a/ln-simln-jamming/src/sink_interceptor.rs
+++ b/ln-simln-jamming/src/sink_interceptor.rs
@@ -1,13 +1,18 @@
-use crate::reputation_interceptor::{endorsement_from_records, ReputationInterceptor};
+use crate::reputation_interceptor::{
+    endorsement_from_records, ReputationInterceptor, ReputationPair,
+};
+use crate::BoxError;
 use async_trait::async_trait;
+use bitcoin::secp256k1::PublicKey;
+use futures::future::join_all;
 use ln_resource_mgr::reputation::EndorsementSignal;
 use simln_lib::sim_node::{
     CustomRecords, ForwardingError, InterceptRequest, InterceptResolution, Interceptor,
 };
 use simln_lib::{NetworkParser, ShortChannelID};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::error::Error;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::{select, time};
 use triggered::{Listener, Trigger};
 
@@ -17,6 +22,28 @@ enum TargetChannelType {
     Peer,
 }
 
+pub struct NetworkReputation {
+    /// The attacker's pairwise outgoing reputation with the target.
+    pub attacker_reputation: Vec<ReputationPair>,
+
+    /// The target's pairwise outgoing reputation with its peers.
+    pub target_reputation: Vec<ReputationPair>,
+}
+
+impl NetworkReputation {
+	/// Gets the number of pairs that the target or attacker has outgoing reputation for.
+    pub fn reputation_count(&self, target: bool) -> usize {
+        if target {
+            &self.target_reputation
+        } else {
+            &self.attacker_reputation
+        }
+        .iter()
+        .filter(|pair| pair.outgoing_reputation())
+        .count()
+    }
+}
+
 // Implements a "sink" attack where an attacking node:
 // - General jams its peers so that htlcs will be endorsed
 // - Holds the endorsed htlcs to trash the target node's reputation with its peers
@@ -24,8 +51,11 @@ enum TargetChannelType {
 // This interceptor wraps an inner reputation interceptor so that we can still operate with regular reputation
 // on the non-attacking nodes. Doing so also allows us access to reputation values for monitoring.
 pub struct SinkInterceptor {
+    target_pubkey: PublicKey,
     /// Keeps track of the target's channels for custom behavior.
     target_channels: HashMap<ShortChannelID, TargetChannelType>,
+    /// List of public keys of the target's honest (non-attacker) peers.
+    honest_peers: Vec<PublicKey>,
     /// Inner reputation monitor that implements jamming mitigation.
     jamming_interceptor: ReputationInterceptor,
     /// Used to control shutdown.
@@ -64,42 +94,109 @@ fn print_request(req: &InterceptRequest) -> String {
 
 impl SinkInterceptor {
     pub fn new_for_network(
-        attacking_alias: String,
-        target_alias: String,
+        attacking_pubkey: PublicKey,
+        target_pubkey: PublicKey,
         edges: &[NetworkParser],
         jamming_interceptor: ReputationInterceptor,
         listener: Listener,
         shutdown: Trigger,
     ) -> Self {
         let mut target_channels = HashMap::new();
+        let mut honest_peers = Vec::new();
 
         for channel in edges.iter() {
-            let node_1_target = channel.node_1.alias == target_alias;
-            let node_2_target = channel.node_2.alias == target_alias;
+            let node_1_target = channel.node_1.pubkey == target_pubkey;
+            let node_2_target = channel.node_2.pubkey == target_pubkey;
 
             if !(node_1_target || node_2_target) {
                 continue;
             }
 
-            let channel_type = if node_1_target && channel.node_2.alias == attacking_alias {
+            let channel_type = if node_1_target && channel.node_2.pubkey == attacking_pubkey {
                 TargetChannelType::Attacker
             } else if node_1_target {
                 TargetChannelType::Peer
-            } else if node_2_target && channel.node_1.alias == attacking_alias {
+            } else if node_2_target && channel.node_1.pubkey == attacking_pubkey {
                 TargetChannelType::Attacker
             } else {
                 TargetChannelType::Peer
             };
 
+            if channel_type == TargetChannelType::Peer {
+                honest_peers.push(if node_1_target {
+                    channel.node_2.pubkey
+                } else {
+                    channel.node_1.pubkey
+                });
+            }
             target_channels.insert(channel.scid, channel_type);
         }
 
         Self {
+            target_pubkey,
+            honest_peers,
             jamming_interceptor,
             target_channels,
             listener,
             shutdown,
         }
+    }
+
+    /// Reports on the current reputation state of the target node with its peers, and the attacker's standing with
+    /// the target.
+    pub async fn get_reputation_status(
+        &self,
+        access_ins: Instant,
+    ) -> Result<NetworkReputation, BoxError> {
+        // Can use regular mapping closures because get_target_pairs is async.
+        let target_reputation_results: Vec<Result<Vec<ReputationPair>, BoxError>> =
+            join_all(self.honest_peers.iter().map(|pubkey| async {
+                self.get_target_pairs(*pubkey, TargetChannelType::Peer, access_ins)
+                    .await
+            }))
+            .await;
+
+        Ok(NetworkReputation {
+            attacker_reputation: self
+                .get_target_pairs(self.target_pubkey, TargetChannelType::Attacker, access_ins)
+                .await?,
+            target_reputation: target_reputation_results
+                .into_iter()
+                .collect::<Result<Vec<Vec<ReputationPair>>, BoxError>>()?
+                .into_iter()
+                .flatten()
+                .collect(),
+        })
+    }
+
+    /// Gets reputation pairs for the node provided, filtering them for channels that the target node is a part of.
+    /// - TargetChannelType::Peer / Node=Peer: reports the target's reputation in the eyes of its peers.
+    /// - TargetChannelType::Attacker / Node=Target: reports the attacker's reputation in the eyes of the target.
+    /// Note that if the node provided is not the target or one of its peers, nothing will be returned.
+    async fn get_target_pairs(
+        &self,
+        node: PublicKey,
+        filter_chan_type: TargetChannelType,
+        access_ins: Instant,
+    ) -> Result<Vec<ReputationPair>, BoxError> {
+        let channels: HashSet<u64> = self
+            .target_channels
+            .iter()
+            .filter(|(_, chan_type)| **chan_type == filter_chan_type)
+            .map(|(scid, _)| *scid)
+            .map(|scid| scid.into()) // TODO: don't double map
+            .collect();
+
+        let reputations: Vec<ReputationPair> = self
+            .jamming_interceptor
+            .list_reputation_pairs(node, access_ins)
+            .await?
+            .iter()
+            .filter(|scid| channels.get(&scid.outgoing_scid).is_some())
+            .map(|pair| *pair)
+            .collect();
+
+        Ok(reputations)
     }
 
     /// Intercepts payments flowing from target -> attacker, holding the htlc for the maximum allowable time to


### PR DESCRIPTION
Add a check that at startup:
* The target has reputation with 50% of its pairs
* The attacker has reputation with 50% of the target's peers
TODO:  check reputation for some htlc amount (eg $10) so that we don't hit reputations that are _just_ over the threshold

It's not worth running a simulation if we don't start with _some_ reputation, because we're not really testing a sink attack if they don't.

