### PR TITLE
multi: Add a htlc amount to reputation checks

### DIFF
--- a/ln-simln-jamming/src/main.rs
+++ b/ln-simln-jamming/src/main.rs
@@ -14,9 +14,9 @@ use simln_lib::interceptors::LatencyIntercepor;
 use simln_lib::sim_node::{Interceptor, SimulatedChannel};
 use simln_lib::{NetworkParser, Simulation, SimulationCfg};
 use simple_logger::SimpleLogger;
-use std::fs;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
+use std::{fs, usize};
 use tokio::task::JoinSet;
 
 #[derive(Serialize, Deserialize)]
@@ -109,30 +109,7 @@ async fn main() -> Result<(), BoxError> {
 
     // Do some preliminary checks on our reputation state - there isn't much point in running if we haven't built up
     // some reputation.
-    let start_state = attack_interceptor
-        .get_reputation_status(clock.clone().now())
-        .await?;
-    if start_state.reputation_count(false)
-        < start_state.attacker_reputation.len() * cli.attacker_reputation_percent as usize / 100
-    {
-        return Err(format!(
-            "no point running simulation when attacker has < 50% good reputation, {}/{}",
-            start_state.reputation_count(false),
-            start_state.attacker_reputation.len(),
-        )
-        .into());
-    }
-
-    if start_state.reputation_count(true)
-        < start_state.target_reputation.len() * cli.target_reputation_percent as usize / 100
-    {
-        return Err(format!(
-            "no point running simulation when target has < 50% good reputation, {}/{}",
-            start_state.reputation_count(true),
-            start_state.target_reputation.len()
-        )
-        .into());
-    }
+    check_reputation_status(&attack_interceptor, &cli, forward_params, clock.now(), true).await?;
 
     let attack_interceptor: Arc<dyn Interceptor> = Arc::new(attack_interceptor);
 
@@ -198,4 +175,74 @@ fn find_pubkey_by_alias(alias: &str, sim_network: &[NetworkParser]) -> Result<Pu
     } else {
         target_channel.node_2.pubkey
     })
+}
+
+/// Gets reputation pairs for the target node and attacking node, logs them and optionally checking that each node
+/// meets the configured threshold of good reputation if require_reputation is set.
+async fn check_reputation_status(
+    attack_interceptor: &SinkInterceptor,
+    cli: &Cli,
+    params: ForwardManagerParams,
+    instant: Instant,
+    require_reputation: bool,
+) -> Result<(), BoxError> {
+    let status = attack_interceptor.get_reputation_status(instant).await?;
+
+    let margin_fee = 1000 + (0.0001 * cli.reputation_margin_msat as f64) as u64;
+
+    let attacker_reputation = status.reputation_count(
+        false,
+        &params,
+        margin_fee,
+        cli.reputation_margin_expiry_blocks,
+    );
+
+    let target_reputation = status.reputation_count(
+        true,
+        &params,
+        margin_fee,
+        cli.reputation_margin_expiry_blocks,
+    );
+
+    log::info!(
+        "Attacker has {} out of {} pairs with reputation",
+        attacker_reputation,
+        status.attacker_reputation.len()
+    );
+
+    log::info!(
+        "Target has {}/{} pairs with reputation with its peers",
+        target_reputation,
+        status.target_reputation.len()
+    );
+
+    if !require_reputation {
+        return Ok(());
+    }
+
+    let attacker_threshold =
+        status.attacker_reputation.len() * cli.attacker_reputation_percent as usize / 100;
+    if attacker_reputation < attacker_threshold {
+        return Err(format!(
+            "attacker has {}/{} good reputation pairs which does not meet threshold {}",
+            attacker_reputation,
+            status.attacker_reputation.len(),
+            attacker_threshold,
+        )
+        .into());
+    }
+
+    let target_threshold =
+        status.target_reputation.len() * cli.target_reputation_percent as usize / 100;
+    if target_reputation < target_threshold {
+        return Err(format!(
+            "target has {}/{} good reputation pairs which does not meet threshold {}",
+            target_reputation,
+            status.target_reputation.len(),
+            target_threshold,
+        )
+        .into());
+    }
+
+    Ok(())
 }

--- a/ln-simln-jamming/src/parsing.rs
+++ b/ln-simln-jamming/src/parsing.rs
@@ -31,6 +31,13 @@ const DEFAULT_ATTACKER_REP_PERCENT: &str = "50";
 /// Default clock speedup to run with regular wall time.
 const DEFAULT_CLOCK_SPEEDUP: &str = "1";
 
+/// Default htlc size that a peer must be able to get endorsed to be considered as having good reputation, $10 at the
+/// time of writing.
+const DEFAULT_REPUTATION_MARGIN_MSAT: &str = "10000000";
+
+/// Default htlc expiry used for calculating reputation margin htlc's risk.
+const DEFAULT_REPUTATION_MARGIN_EXIPRY: &str = "200";
+
 #[derive(Parser)]
 #[command(version, about)]
 pub struct Cli {
@@ -66,6 +73,17 @@ pub struct Cli {
     /// Speed up multiplier to add to the wall clock to run the simulation faster.
     #[arg(long, default_value = DEFAULT_CLOCK_SPEEDUP)]
     pub clock_speedup: u32,
+
+    /// The htlc amount that a peer must be able to get endorsed to be considered as having a good reputation, expressed
+    /// in msat. This will be converted to a fee using a base fee of 1000 msat and a proportional charge of 0.01% of the
+    /// amount.
+    #[arg(long, default_value = DEFAULT_REPUTATION_MARGIN_MSAT)]
+    pub reputation_margin_msat: u64,
+
+    /// The htlc expiry that is used to assess whether a peer has sufficient reputation to forward a htlc, expressed
+    /// in blocks.
+    #[arg(long, default_value = DEFAULT_REPUTATION_MARGIN_EXIPRY)]
+    pub reputation_margin_expiry_blocks: u32,
 }
 
 impl Cli {

--- a/ln-simln-jamming/src/reputation_interceptor.rs
+++ b/ln-simln-jamming/src/reputation_interceptor.rs
@@ -13,9 +13,7 @@ use std::ops::Sub;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use ln_resource_mgr::outgoing_reputation::{
-    ForwardManager, ForwardManagerParams, ReputationParams,
-};
+use ln_resource_mgr::outgoing_reputation::{ForwardManager, ForwardManagerParams};
 use ln_resource_mgr::{
     EndorsementSignal, ForwardResolution, ForwardingOutcome, HtlcRef, ProposedForward,
     ReputationError, ReputationManager,
@@ -79,6 +77,7 @@ pub struct ReputationInterceptor {
 
 impl ReputationInterceptor {
     pub fn new_for_network(
+        params: ForwardManagerParams,
         edges: &[NetworkParser],
         clock: Arc<dyn InstantClock + Send + Sync>,
     ) -> Result<Self, BoxError> {
@@ -88,16 +87,7 @@ impl ReputationInterceptor {
             ($network_nodes:expr, $node_pubkey:expr, $node_alias:expr, $channel:expr) => {
                 match $network_nodes.entry($node_pubkey) {
                     Entry::Vacant(e) => {
-                        let forward_manager = ForwardManager::new(ForwardManagerParams {
-                            reputation_params: ReputationParams {
-                                revenue_window: Duration::from_secs(14 * 24 * 60 * 60),
-                                reputation_multiplier: 12,
-                                resolution_period: Duration::from_secs(90),
-                                expected_block_speed: Some(Duration::from_secs(10 * 60 * 60)),
-                            },
-                            general_slot_portion: 50,
-                            general_liquidity_portion: 50,
-                        });
+                        let forward_manager = ForwardManager::new(params);
 
                         let _ = forward_manager
                             .add_channel($channel.scid.into(), $channel.capacity_msat)?;
@@ -138,12 +128,13 @@ impl ReputationInterceptor {
     /// Creates a network from the set of edges provided and bootstraps the reputation of nodes in the network using
     /// the historical forwards provided. Forwards are expected to be sorted by added_ns in ascending order.
     pub async fn new_with_bootstrap(
+        params: ForwardManagerParams,
         edges: &[NetworkParser],
         history: &[BootstrapForward],
         clock: Arc<dyn InstantClock + Send + Sync>,
     ) -> Result<Self, BoxError> {
         let mut interceptor =
-            Self::new_for_network(edges, clock).map_err(|_| "could not create network")?;
+            Self::new_for_network(params, edges, clock).map_err(|_| "could not create network")?;
         interceptor.bootstrap_network_history(history).await?;
         Ok(interceptor)
     }

--- a/ln-simln-jamming/src/reputation_interceptor.rs
+++ b/ln-simln-jamming/src/reputation_interceptor.rs
@@ -61,9 +61,9 @@ pub struct ReputationPair {
 }
 
 impl ReputationPair {
-    pub fn outgoing_reputation(&self) -> bool {
-        // TODO: for what htlc amount?
-        self.outgoing_reputation > self.incoming_revenue
+    /// Determines whether a pair has sufficient reputation for the htlc risk provided.
+    pub fn outgoing_reputation(&self, risk: u64) -> bool {
+        self.outgoing_reputation > self.incoming_revenue + risk as i64
     }
 }
 


### PR DESCRIPTION
Since reputation is assessed for a specific htlc, it makes sense to add a htlc amount to our reputation checks - ie, a peer is considered to have good reputation if they can get a htlc of size X endorsed.

This helps to filter out cases where a reputation pair is _just_  positive but can't actually get any meaningfully sized htlcs endorsed.