### PR TITLE
multi: switch to generics for clock and fixup cltv

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1709,7 +1709,7 @@ dependencies = [
 [[package]]
 name = "simln-lib"
 version = "0.1.0"
-source = "git+https://github.com/carlaKC/sim-ln?rev=67284df54cc3189438f66e26adfc1f304d9eba00#67284df54cc3189438f66e26adfc1f304d9eba00"
+source = "git+https://github.com/carlaKC/sim-ln?rev=e55133e#e55133e9f68f10f1608e24034cf19d0249c53603"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/ln-resource-mgr/src/outgoing_reputation.rs
+++ b/ln-resource-mgr/src/outgoing_reputation.rs
@@ -395,7 +395,10 @@ mod reputation_tracker {
             let in_flight_total_risk = self.total_in_flight_risk();
             let htlc_risk = self
                 .params
-                .htlc_risk(forward.fee_msat(), forward.expiry_delta());
+                // The underlying simulation is block height agnostic, and starts its routes with a height of zero, so
+                // we can just use the incoming expiry to reflect "maximum time htlc can be held on channel", because
+                // we're calculating expiry_in_height - 0.
+                .htlc_risk(forward.fee_msat(), forward.expiry_in_height);
 
             Ok(ReputationCheck {
                 outgoing_reputation,

--- a/ln-simln-jamming/Cargo.toml
+++ b/ln-simln-jamming/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-simln-lib = { git = "https://github.com/carlaKC/sim-ln", rev = "67284df54cc3189438f66e26adfc1f304d9eba00" }
+simln-lib = { git = "https://github.com/carlaKC/sim-ln", rev = "e55133e" }
 ln-resource-mgr = { path = "../ln-resource-mgr" }
 bitcoin = { version = "0.30.1" }
 async-trait = "0.1.73"

--- a/ln-simln-jamming/src/main.rs
+++ b/ln-simln-jamming/src/main.rs
@@ -92,9 +92,9 @@ async fn main() -> Result<(), BoxError> {
         general_liquidity_portion: 50,
     };
 
-    // TODO: these should be shared with simln!!
     let (shutdown, listener) = triggered::trigger();
     let attack_interceptor = SinkInterceptor::new_for_network(
+        clock.clone(),
         attacker_pubkey,
         target_pubkey,
         &sim_network,
@@ -241,13 +241,16 @@ fn get_reputation_margin_fee(cli: &Cli) -> u64 {
 }
 /// Gets reputation pairs for the target node and attacking node, logs them and optionally checking that each node
 /// meets the configured threshold of good reputation if require_reputation is set.
-async fn check_reputation_status(
-    attack_interceptor: &SinkInterceptor,
+async fn check_reputation_status<C>(
+    attack_interceptor: &SinkInterceptor<C>,
     cli: &Cli,
     params: ForwardManagerParams,
     instant: Instant,
     require_reputation: bool,
-) -> Result<(), BoxError> {
+) -> Result<(), BoxError>
+where
+    C: InstantClock + Clock,
+{
     let status = attack_interceptor.get_reputation_status(instant).await?;
 
     let margin_fee = get_reputation_margin_fee(cli);

--- a/ln-simln-jamming/src/main.rs
+++ b/ln-simln-jamming/src/main.rs
@@ -86,7 +86,7 @@ async fn main() -> Result<(), BoxError> {
             revenue_window: Duration::from_secs(14 * 24 * 60 * 60),
             reputation_multiplier: 12,
             resolution_period: Duration::from_secs(90),
-            expected_block_speed: Some(Duration::from_secs(10 * 60 * 60)),
+            expected_block_speed: Some(Duration::from_secs(10 * 60)),
         },
         general_slot_portion: 50,
         general_liquidity_portion: 50,


### PR DESCRIPTION
* Trait objects aren't necessary for clock; we don't need to use hetrogenous erased impls of the trait
* Fix incorrect block speed constant
* Use incoming expiry height rather than cltv delta for opportunity cost (we want the number of blocks that the htlc can be held for from the current height, and simln doesn't set a block heigh so `incoming_expiry - height = incoming_expiry`)