### PR TITLE
multi: write results to file and use reputation interceptor to general jam

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -950,6 +950,9 @@ checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 [[package]]
 name = "ln-resource-mgr"
 version = "0.1.0"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "ln-simln-jamming"
@@ -1681,18 +1684,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.215"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
+checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.215"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
+checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/ln-resource-mgr/Cargo.toml
+++ b/ln-resource-mgr/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+serde = "1.0.217"

--- a/ln-resource-mgr/src/lib.rs
+++ b/ln-resource-mgr/src/lib.rs
@@ -1,6 +1,7 @@
 mod decaying_average;
 pub mod outgoing_reputation;
 
+use serde::Serialize;
 use std::error::Error;
 use std::fmt::Display;
 use std::time::Instant;
@@ -88,7 +89,7 @@ impl Display for ReputationError {
 }
 
 /// The different possible endorsement signals on a htlc's update_add message.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
 pub enum EndorsementSignal {
     Unendorsed,
     Endorsed,
@@ -103,7 +104,7 @@ impl Display for EndorsementSignal {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub enum ForwardingOutcome {
     /// Forward the outgoing htlc with the endorsement signal provided.
     Forward(EndorsementSignal),
@@ -120,7 +121,7 @@ impl Display for ForwardingOutcome {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub enum FailureReason {
     /// There is no space in the outgoing channel's general resource bucket, so the htlc should be failed back. It
     /// may be retired with endorsement set to gain access to protected resources.
@@ -130,7 +131,7 @@ pub enum FailureReason {
 }
 
 /// A snapshot of the reputation and resources available for a forward.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct AllocationCheck {
     /// The reputation values used to compare the incoming channel's revenue to the outgoing channel's reputation for
     /// the htlc proposed.
@@ -169,7 +170,7 @@ impl AllocationCheck {
 }
 
 /// A snapshot of a reputation check for a htlc forward.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct ReputationCheck {
     pub outgoing_reputation: i64,
     pub incoming_revenue: i64,
@@ -189,7 +190,7 @@ impl ReputationCheck {
 }
 
 /// A snapshot of the resource check for a htlc forward.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct ResourceCheck {
     pub general_slots_used: u16,
     pub general_slots_availabe: u16,
@@ -248,7 +249,7 @@ impl Display for ForwardResolution {
 }
 
 /// A unique identifier for a htlc on a channel.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize)]
 pub struct HtlcRef {
     pub channel_id: u64,
     /// The unique index used to refer to the htlc in update_add_htlc.

--- a/ln-resource-mgr/src/lib.rs
+++ b/ln-resource-mgr/src/lib.rs
@@ -2,6 +2,7 @@ mod decaying_average;
 pub mod outgoing_reputation;
 
 use serde::Serialize;
+use std::collections::HashMap;
 use std::error::Error;
 use std::fmt::Display;
 use std::time::Instant;
@@ -316,6 +317,13 @@ impl ProposedForward {
     }
 }
 
+/// Provides a reputation check snapshot for an incoming/outgoing channel pair.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReputationSnapshot {
+    pub outgoing_reputation: i64,
+    pub incoming_revenue: i64,
+}
+
 /// Validates that an msat amount doesn't exceed the total supply cap of bitcoin and casts to i64 to be used in
 /// places where we're dealing with negative numbers. Once we've validated that we're below the supply cap, we can
 /// safely cast to i64 because [`u64::Max`] < total bitcoin supply cap.
@@ -372,4 +380,10 @@ pub trait ReputationManager {
         resolution: ForwardResolution,
         resolved_instant: Instant,
     ) -> Result<(), ReputationError>;
+
+    /// Provides reputation snapshots of per channel at the instant provided.
+    fn list_reputation(
+        &self,
+        access_ins: Instant,
+    ) -> Result<HashMap<u64, ReputationSnapshot>, ReputationError>;
 }

--- a/ln-simln-jamming/src/analysis.rs
+++ b/ln-simln-jamming/src/analysis.rs
@@ -1,0 +1,281 @@
+use crate::BoxError;
+use bitcoin::secp256k1::PublicKey;
+use csv::WriterBuilder;
+use ln_resource_mgr::{AllocationCheck, ProposedForward};
+use serde::ser::SerializeStruct;
+use serde::{Serialize, Serializer};
+use std::collections::HashMap;
+use std::fs::{metadata, OpenOptions};
+
+/// Implemented to report forwards for analytics and data recording.
+pub trait ForwardReporter: Send + Sync {
+    fn report_forward(
+        &mut self,
+        forwarding_node: PublicKey,
+        decision: AllocationCheck,
+        forward: ProposedForward,
+    ) -> Result<(), BoxError>;
+}
+
+struct Record {
+    forward: ProposedForward,
+    decision: AllocationCheck,
+}
+
+impl Serialize for Record {
+    /// Serializes a record as a single flat struct, including forwarding outcome for its allocation check. Implemented
+    /// as custom serialization because serde + csv can't handle headers for custom structs, and we need to do some
+    /// transformations on the data.
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut state = serializer.serialize_struct("Record", 14)?;
+        state.serialize_field("incoming_channel_id", &self.forward.incoming_ref.channel_id)?;
+        state.serialize_field("outgoing_channel_id", &self.forward.outgoing_channel_id)?;
+        state.serialize_field("amount_in_msat", &self.forward.amount_in_msat)?;
+        state.serialize_field("amount_out_msat", &self.forward.amount_out_msat)?;
+        state.serialize_field("expiry_in_height", &self.forward.expiry_in_height)?;
+        state.serialize_field("expiry_out_height", &self.forward.expiry_out_height)?;
+        state.serialize_field("incoming_endorsed", &self.forward.incoming_endorsed)?;
+        state.serialize_field(
+            "forwarding_outcome",
+            &self
+                .decision
+                .forwarding_outcome(self.forward.amount_in_msat, self.forward.incoming_endorsed),
+        )?;
+        state.serialize_field(
+            "incoming_revenue",
+            &self.decision.reputation_check.incoming_revenue,
+        )?;
+        state.serialize_field(
+            "outgoing_reputation",
+            &self.decision.reputation_check.outgoing_reputation,
+        )?;
+        state.serialize_field("htlc_risk", &self.decision.reputation_check.htlc_risk)?;
+        state.serialize_field(
+            "in_flight_risk",
+            &self.decision.reputation_check.in_flight_total_risk,
+        )?;
+        state.serialize_field(
+            "slots_available",
+            &self.decision.resource_check.general_slots_availabe,
+        )?;
+        state.serialize_field(
+            "liquidity_available",
+            &self
+                .decision
+                .resource_check
+                .general_liquidity_msat_available,
+        )?;
+        state.end()
+    }
+}
+
+/// Tracks a set of nodes to record forward decisions for and periodically writes them to disk.
+pub struct BatchForwardWriter {
+    /// The set of nodes that we want to store forward results for.
+    nodes: HashMap<PublicKey, (Vec<Record>, String)>,
+    /// The number of forwards to accumulate in memory before writing to disk.
+    batch_size: u16,
+    record_count: u16,
+}
+
+impl BatchForwardWriter {
+    pub fn new(nodes: &[(PublicKey, String)], batch_size: u16) -> Self {
+        Self {
+            nodes: nodes
+                .iter()
+                .cloned()
+                .map(|(pubkey, alias)| (pubkey, (vec![], alias)))
+                .collect(),
+            batch_size,
+            record_count: 0,
+        }
+    }
+
+    pub fn write(&mut self) -> Result<(), BoxError> {
+        if self.record_count < self.batch_size {
+            return Ok(());
+        }
+
+        for (pubkey, (records, alias)) in self.nodes.iter_mut() {
+            if records.is_empty() {
+                continue;
+            }
+
+            write_records_for_node(get_filename(pubkey, alias.to_string()), records)?;
+            records.clear();
+        }
+        self.record_count = 0;
+
+        Ok(())
+    }
+}
+
+fn get_filename(node: &PublicKey, alias: String) -> String {
+    format!("{alias}_{}.csv", &node.to_string()[0..6])
+}
+
+fn write_records_for_node(filename: String, records: &[Record]) -> Result<(), BoxError> {
+    let file_exists = metadata(&filename).is_ok();
+
+    let file = OpenOptions::new()
+        .append(true)
+        .create(true)
+        .open(&filename)?;
+
+    let mut writer = WriterBuilder::new()
+        .has_headers(!file_exists)
+        .from_writer(file);
+
+    for record in records {
+        writer.serialize(record)?;
+    }
+
+    writer.flush().map_err(|e| e.into())
+}
+
+impl ForwardReporter for BatchForwardWriter {
+    /// Queues a forward for write to disk if it's one of the nodes that we're interested in.
+    fn report_forward(
+        &mut self,
+        forwarding_node: PublicKey,
+        decision: AllocationCheck,
+        forward: ProposedForward,
+    ) -> Result<(), BoxError> {
+        if let Some((records, _)) = self.nodes.get_mut(&forwarding_node) {
+            records.push(Record { decision, forward });
+            self.record_count += 1;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::read_to_string;
+    use std::path::Path;
+    use std::time::SystemTime;
+
+    use crate::analysis::get_filename;
+    use crate::test_utils::{get_random_keypair, test_allocation_check, test_proposed_forward};
+
+    use super::{BatchForwardWriter, ForwardReporter};
+
+    /// Tests that only forwards on nodes of interest are queued for writing.
+    #[test]
+    fn test_report_forward() {
+        let node_0 = get_random_keypair().1;
+        let node_1 = get_random_keypair().1;
+
+        let mut writer = BatchForwardWriter::new(&[(node_0, "0".to_string())], 5);
+
+        // Tracked node reported.
+        let tracked_forward = test_proposed_forward(0);
+        writer
+            .report_forward(node_0, test_allocation_check(true), tracked_forward.clone())
+            .unwrap();
+        assert_eq!(writer.record_count, 1);
+
+        // Non-tracked node ignored.
+        writer
+            .report_forward(
+                node_1,
+                test_allocation_check(true),
+                test_proposed_forward(1),
+            )
+            .unwrap();
+        assert_eq!(writer.record_count, 1);
+
+        let node_0_records = &writer.nodes.get(&node_0).unwrap().0;
+        assert_eq!(node_0_records.len(), 1);
+        assert_eq!(node_0_records[0].forward, tracked_forward);
+    }
+
+    /// Tests flushing of records to disk, using the current time to ensure a unique filename that can be cleaned up
+    /// after.
+    #[test]
+    fn test_write_records() {
+        let node_0 = get_random_keypair().1;
+        let node_1 = get_random_keypair().1;
+
+        let alias = format!(
+            "test_{}",
+            SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+        );
+        let filename = get_filename(&node_0, alias.clone());
+
+        let mut writer = BatchForwardWriter::new(&[(node_0, alias)], 2);
+
+        // Track a forward that should be written to disk.
+        writer
+            .report_forward(
+                node_0,
+                test_allocation_check(true),
+                test_proposed_forward(0),
+            )
+            .unwrap();
+        assert_eq!(writer.record_count, 1);
+
+        // Writing with a single record shouldn't go to disk yet.
+        writer.write().unwrap();
+        assert!(!Path::new(&filename).exists());
+
+        // Non-tracked node ignored and not written to disk.
+        writer
+            .report_forward(
+                node_1,
+                test_allocation_check(true),
+                test_proposed_forward(1),
+            )
+            .unwrap();
+        writer.write().unwrap();
+        assert!(!Path::new(&filename).exists());
+
+        // Tracked record meets threshold is written to disk with a header line and our two records.
+        writer
+            .report_forward(
+                node_0,
+                test_allocation_check(true),
+                test_proposed_forward(2),
+            )
+            .unwrap();
+        assert_eq!(writer.record_count, 2);
+
+        writer.write().unwrap();
+        assert_eq!(read_to_string(&filename).unwrap().lines().count(), 3);
+
+        // Write three more tracked forward and assert the file is updated.
+        writer
+            .report_forward(
+                node_0,
+                test_allocation_check(true),
+                test_proposed_forward(3),
+            )
+            .unwrap();
+        writer
+            .report_forward(
+                node_0,
+                test_allocation_check(true),
+                test_proposed_forward(4),
+            )
+            .unwrap();
+        writer
+            .report_forward(
+                node_0,
+                test_allocation_check(true),
+                test_proposed_forward(5),
+            )
+            .unwrap();
+
+        writer.write().unwrap();
+        assert_eq!(read_to_string(&filename).unwrap().lines().count(), 6);
+
+        std::fs::remove_file(filename).unwrap();
+    }
+}

--- a/ln-simln-jamming/src/lib.rs
+++ b/ln-simln-jamming/src/lib.rs
@@ -2,6 +2,7 @@ use ln_resource_mgr::EndorsementSignal;
 use simln_lib::sim_node::CustomRecords;
 use std::error::Error;
 
+pub mod analysis;
 pub mod clock;
 pub mod parsing;
 pub mod reputation_interceptor;

--- a/ln-simln-jamming/src/main.rs
+++ b/ln-simln-jamming/src/main.rs
@@ -16,6 +16,7 @@ use simln_lib::interceptors::LatencyIntercepor;
 use simln_lib::sim_node::{Interceptor, SimulatedChannel};
 use simln_lib::{NetworkParser, Simulation, SimulationCfg};
 use simple_logger::SimpleLogger;
+use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use std::{fs, usize};
@@ -132,6 +133,7 @@ async fn main() -> Result<(), BoxError> {
         ReputationInterceptor::new_with_bootstrap(
             forward_params,
             &sim_network,
+            HashMap::new(),
             &history,
             clock.clone(),
             Some(results_writer),

--- a/ln-simln-jamming/src/main.rs
+++ b/ln-simln-jamming/src/main.rs
@@ -1,6 +1,7 @@
 use bitcoin::secp256k1::PublicKey;
 use clap::Parser;
 use ln_resource_mgr::outgoing_reputation::{ForwardManagerParams, ReputationParams};
+use ln_simln_jamming::analysis::BatchForwardWriter;
 use ln_simln_jamming::clock::InstantClock;
 use ln_simln_jamming::parsing::{history_from_file, Cli};
 use ln_simln_jamming::reputation_interceptor::{ReputationInterceptor, ReputationMonitor};
@@ -98,11 +99,12 @@ async fn main() -> Result<(), BoxError> {
         attacker_pubkey,
         target_pubkey,
         &sim_network,
-        ReputationInterceptor::new_with_bootstrap(
+        ReputationInterceptor::<BatchForwardWriter>::new_with_bootstrap(
             forward_params,
             &sim_network,
             &history,
             clock.clone(),
+            None,
             shutdown.clone(),
         )
         .await?,

--- a/ln-simln-jamming/src/parsing.rs
+++ b/ln-simln-jamming/src/parsing.rs
@@ -42,6 +42,9 @@ const DEFAULT_REPUTATION_MARGIN_EXIPRY: &str = "200";
 /// in seconds.
 const DEFAULT_ATTACKER_POLL_SECONDS: &str = "300";
 
+/// The default batch size for writing results to disk.
+const DEFAULT_RESULT_BATCH_SIZE: &str = "500";
+
 #[derive(Parser)]
 #[command(version, about)]
 pub struct Cli {
@@ -92,6 +95,10 @@ pub struct Cli {
     /// The interval to poll whether the attacker still has reputation with the target node, expressed in seconds.
     #[arg(long, default_value = DEFAULT_ATTACKER_POLL_SECONDS)]
     pub attacker_poll_interval_seconds: u64,
+
+    /// The size of results batches to write to disk.
+    #[arg(long, default_value = DEFAULT_RESULT_BATCH_SIZE)]
+    pub result_batch_size: u16,
 }
 
 impl Cli {

--- a/ln-simln-jamming/src/sink_interceptor.rs
+++ b/ln-simln-jamming/src/sink_interceptor.rs
@@ -411,14 +411,11 @@ mod tests {
     use std::sync::Arc;
 
     use crate::reputation_interceptor::{HtlcAdd, ReputationMonitor, ReputationPair};
-    use crate::test_utils::{get_random_keypair, setup_test_request};
+    use crate::test_utils::{get_random_keypair, setup_test_request, test_allocation_check};
     use crate::{endorsement_from_records, records_from_endorsement, test_utils, BoxError};
     use async_trait::async_trait;
     use bitcoin::secp256k1::PublicKey;
-    use ln_resource_mgr::{
-        AllocationCheck, EndorsementSignal, ForwardingOutcome, ReputationCheck, ReputationError,
-        ResourceCheck,
-    };
+    use ln_resource_mgr::{AllocationCheck, EndorsementSignal, ReputationError};
     use mockall::mock;
     use mockall::predicate::function;
     use simln_lib::clock::SimulationClock;
@@ -487,32 +484,6 @@ mod tests {
                     && args.outgoing_channel_id.unwrap() == expected_outgoing
             }))
             .return_once(|_| {});
-    }
-
-    fn test_allocation_check(forward_succeeds: bool) -> AllocationCheck {
-        let check = AllocationCheck {
-            reputation_check: ReputationCheck {
-                outgoing_reputation: 100_000,
-                incoming_revenue: if forward_succeeds { 0 } else { 200_000 },
-                in_flight_total_risk: 0,
-                htlc_risk: 0,
-            },
-            resource_check: ResourceCheck {
-                general_slots_used: 0,
-                general_slots_availabe: 10,
-                general_liquidity_msat_used: 0,
-                general_liquidity_msat_available: 100_000,
-            },
-        };
-
-        assert!(
-            matches!(
-                check.forwarding_outcome(0, EndorsementSignal::Endorsed),
-                ForwardingOutcome::Forward(_)
-            ) == forward_succeeds
-        );
-
-        check
     }
 
     /// Tests attacker interception of htlcs from the target.

--- a/ln-simln-jamming/src/sink_interceptor.rs
+++ b/ln-simln-jamming/src/sink_interceptor.rs
@@ -411,11 +411,10 @@ mod tests {
     use std::sync::Arc;
 
     use crate::reputation_interceptor::{HtlcAdd, ReputationMonitor, ReputationPair};
-    use crate::test_utils::get_random_keypair;
+    use crate::test_utils::{get_random_keypair, setup_test_request};
     use crate::{endorsement_from_records, records_from_endorsement, test_utils, BoxError};
     use async_trait::async_trait;
     use bitcoin::secp256k1::PublicKey;
-    use lightning::ln::PaymentHash;
     use ln_resource_mgr::{
         AllocationCheck, EndorsementSignal, ForwardingOutcome, ReputationCheck, ReputationError,
         ResourceCheck,
@@ -423,9 +422,7 @@ mod tests {
     use mockall::mock;
     use mockall::predicate::function;
     use simln_lib::clock::SimulationClock;
-    use simln_lib::sim_node::{
-        CustomRecords, ForwardingError, HtlcRef, InterceptRequest, InterceptResolution, Interceptor,
-    };
+    use simln_lib::sim_node::{InterceptRequest, InterceptResolution, Interceptor};
     use simln_lib::ShortChannelID;
 
     use super::{SinkInterceptor, TargetChannelType};
@@ -476,39 +473,6 @@ mod tests {
         );
 
         interceptor
-    }
-
-    fn setup_test_request(
-        forwarding_node: PublicKey,
-        channel_in: u64,
-        channel_out: u64,
-        incoming_endorsed: EndorsementSignal,
-    ) -> (
-        InterceptRequest,
-        tokio::sync::mpsc::Receiver<
-            Result<Result<CustomRecords, ForwardingError>, Box<dyn Error + Send + Sync + 'static>>,
-        >,
-    ) {
-        let (response, receiver) = tokio::sync::mpsc::channel(1);
-
-        (
-            InterceptRequest {
-                forwarding_node,
-                payment_hash: PaymentHash([1; 32]),
-                incoming_htlc: HtlcRef {
-                    channel_id: channel_in.into(),
-                    index: 0,
-                },
-                incoming_custom_records: records_from_endorsement(incoming_endorsed),
-                outgoing_channel_id: Some(ShortChannelID::from(channel_out)),
-                incoming_amount_msat: 100,
-                outgoing_amount_msat: 50,
-                incoming_expiry_height: 600_010,
-                outgoing_expiry_height: 600_000,
-                response,
-            },
-            receiver,
-        )
     }
 
     /// Primes the mock to expect intercept_htlc called with the request provided.

--- a/ln-simln-jamming/src/test_utils.rs
+++ b/ln-simln-jamming/src/test_utils.rs
@@ -1,14 +1,13 @@
 use std::error::Error;
 use std::time::Instant;
 
+use bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey};
 use lightning::ln::PaymentHash;
 use ln_resource_mgr::{
     AllocationCheck, EndorsementSignal, ForwardingOutcome, ProposedForward, ReputationCheck,
     ResourceCheck,
 };
 use rand::{distributions::Uniform, Rng};
-
-use bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey};
 use simln_lib::sim_node::{CustomRecords, ForwardingError, InterceptRequest};
 use simln_lib::ShortChannelID;
 

--- a/ln-simln-jamming/src/test_utils.rs
+++ b/ln-simln-jamming/src/test_utils.rs
@@ -1,6 +1,18 @@
+use std::error::Error;
+use std::time::Instant;
+
+use lightning::ln::PaymentHash;
+use ln_resource_mgr::{
+    AllocationCheck, EndorsementSignal, ForwardingOutcome, ProposedForward, ReputationCheck,
+    ResourceCheck,
+};
 use rand::{distributions::Uniform, Rng};
 
 use bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey};
+use simln_lib::sim_node::{CustomRecords, ForwardingError, InterceptRequest};
+use simln_lib::ShortChannelID;
+
+use crate::records_from_endorsement;
 
 #[allow(dead_code)]
 pub fn get_random_bytes(size: usize) -> Vec<u8> {
@@ -16,5 +28,83 @@ pub fn get_random_keypair() -> (SecretKey, PublicKey) {
         if let Ok(sk) = SecretKey::from_slice(&get_random_bytes(32)) {
             return (sk, PublicKey::from_secret_key(&Secp256k1::new(), &sk));
         }
+    }
+}
+
+#[allow(dead_code, clippy::type_complexity)]
+pub fn setup_test_request(
+    forwarding_node: PublicKey,
+    channel_in: u64,
+    channel_out: u64,
+    incoming_endorsed: EndorsementSignal,
+) -> (
+    InterceptRequest,
+    tokio::sync::mpsc::Receiver<
+        Result<Result<CustomRecords, ForwardingError>, Box<dyn Error + Send + Sync + 'static>>,
+    >,
+) {
+    let (response, receiver) = tokio::sync::mpsc::channel(1);
+
+    (
+        InterceptRequest {
+            forwarding_node,
+            payment_hash: PaymentHash([1; 32]),
+            incoming_htlc: simln_lib::sim_node::HtlcRef {
+                channel_id: channel_in.into(),
+                index: 0,
+            },
+            incoming_custom_records: records_from_endorsement(incoming_endorsed),
+            outgoing_channel_id: Some(ShortChannelID::from(channel_out)),
+            incoming_amount_msat: 100,
+            outgoing_amount_msat: 50,
+            incoming_expiry_height: 600_010,
+            outgoing_expiry_height: 600_000,
+            response,
+        },
+        receiver,
+    )
+}
+
+#[allow(dead_code)]
+pub fn test_allocation_check(forward_succeeds: bool) -> AllocationCheck {
+    let check = AllocationCheck {
+        reputation_check: ReputationCheck {
+            outgoing_reputation: 100_000,
+            incoming_revenue: if forward_succeeds { 0 } else { 200_000 },
+            in_flight_total_risk: 0,
+            htlc_risk: 0,
+        },
+        resource_check: ResourceCheck {
+            general_slots_used: 0,
+            general_slots_availabe: 10,
+            general_liquidity_msat_used: 0,
+            general_liquidity_msat_available: 100_000,
+        },
+    };
+
+    assert!(
+        matches!(
+            check.forwarding_outcome(0, EndorsementSignal::Endorsed),
+            ForwardingOutcome::Forward(_)
+        ) == forward_succeeds
+    );
+
+    check
+}
+
+#[allow(dead_code)]
+pub fn test_proposed_forward(id: u64) -> ProposedForward {
+    ProposedForward {
+        incoming_ref: ln_resource_mgr::HtlcRef {
+            channel_id: 1,
+            htlc_index: id,
+        },
+        outgoing_channel_id: 2,
+        amount_in_msat: 2000,
+        amount_out_msat: 1000,
+        expiry_in_height: 80,
+        expiry_out_height: 40,
+        added_at: Instant::now(),
+        incoming_endorsed: EndorsementSignal::Endorsed,
     }
 }


### PR DESCRIPTION
* Add the ability to specify a set of nodes that we're interested in writing their forwards to disk
* This is done in `reputation_interceptor` because this is where we have access to interesting reputation numbers
* To get general jams to be reported, the `reputation_interceptor` is updated to assign no general resources to some nodes, which will result in them being bounced by the `reputation_interceptor` rather than needing to rely on custom logic in `sink_interceptor`