### PR TITLE
Add congestion bucket for attack times

### DIFF
--- a/ln-resource-mgr/src/htlc_manager.rs
+++ b/ln-resource-mgr/src/htlc_manager.rs
@@ -195,6 +195,7 @@ mod tests {
 
     fn get_test_htlc(
         outgoing_channel: u64,
+        incoming_endorsed: bool,
         bucket: ResourceBucketType,
         fee_msat: u64,
     ) -> InFlightHtlc {
@@ -204,150 +205,256 @@ mod tests {
             outgoing_amt_msat: 2000,
             fee_msat,
             added_instant: Instant::now(),
-            incoming_endorsed: EndorsementSignal::Endorsed,
+            incoming_endorsed: if incoming_endorsed {
+                EndorsementSignal::Endorsed
+            } else {
+                EndorsementSignal::Unendorsed
+            },
             bucket,
         }
     }
 
+    /// Tests adding and removal of HTLCs from the tracker.
     #[test]
     fn test_add_htlc() {
         let mut tracker = get_test_manager();
         let channel_0 = 0;
         let channel_1 = 1;
+
+        // HTLC forwarded on 0 -> 1.
+        let htlc_1_ref = HtlcRef {
+            channel_id: channel_0,
+            htlc_index: 0,
+        };
+        let htlc_1 = get_test_htlc(channel_1, true, ResourceBucketType::Protected, 1000);
+        tracker.add_htlc(htlc_1_ref, htlc_1.clone()).unwrap();
+
+        // Check that HTLC counts for buckets are correct.
+        assert_eq!(
+            tracker.bucket_in_flight_count(channel_1, ResourceBucketType::Protected),
+            1
+        );
+        assert_eq!(
+            tracker.bucket_in_flight_count(channel_1, ResourceBucketType::General),
+            0
+        );
+        assert_eq!(
+            tracker.bucket_in_flight_count(channel_0, ResourceBucketType::Protected),
+            0
+        );
+        assert_eq!(
+            tracker.bucket_in_flight_count(channel_0, ResourceBucketType::General),
+            0
+        );
+
+        // Duplicate add fails.
+        assert!(matches!(
+            tracker.add_htlc(htlc_1_ref, htlc_1.clone()).err().unwrap(),
+            ReputationError::ErrDuplicateHtlc(_)
+        ));
+
+        // HTLC forwarded on  1 -> 0.
+        let htlc_2_ref = HtlcRef {
+            channel_id: channel_1,
+            htlc_index: 0,
+        };
+        let htlc_2 = get_test_htlc(channel_0, false, ResourceBucketType::General, 2000);
+
+        // Remove unknown fails.
+        assert!(matches!(
+            tracker
+                .remove_htlc(htlc_2.outgoing_channel_id, htlc_2_ref)
+                .err()
+                .unwrap(),
+            ReputationError::ErrForwardNotFound(_, _)
+        ));
+
+        assert!(tracker.add_htlc(htlc_2_ref, htlc_2).is_ok());
+        assert_eq!(
+            tracker.bucket_in_flight_count(channel_1, ResourceBucketType::Protected),
+            1
+        );
+        assert_eq!(
+            tracker.bucket_in_flight_count(channel_1, ResourceBucketType::General),
+            0
+        );
+        assert_eq!(
+            tracker.bucket_in_flight_count(channel_0, ResourceBucketType::Protected),
+            0
+        );
+        assert_eq!(
+            tracker.bucket_in_flight_count(channel_0, ResourceBucketType::General),
+            1
+        );
+
+        // Removing outgoing htlc updates buckets accordingly.
+        assert!(tracker
+            .remove_htlc(htlc_1.outgoing_channel_id, htlc_1_ref)
+            .is_ok());
+        assert_eq!(
+            tracker.bucket_in_flight_count(channel_1, ResourceBucketType::Protected),
+            0
+        );
+        assert_eq!(
+            tracker.bucket_in_flight_count(channel_1, ResourceBucketType::General),
+            0
+        );
+    }
+
+    /// Tests calculation of in flight risk on outgoing channels.
+    #[test]
+    fn test_in_flight_risk() {
+        let mut tracker = get_test_manager();
+        let channel_0 = 0;
+        let channel_1 = 1;
         let channel_2 = 2;
+
+        assert_eq!(
+            tracker.channel_in_flight_risk(ChannelFilter::OutgoingChannel(channel_0)),
+            0
+        );
+        assert_eq!(
+            tracker.channel_in_flight_risk(ChannelFilter::OutgoingChannel(channel_1)),
+            0
+        );
 
         // Endorsed htlc contribute to in flight risk and count, 0 -> 1.
         let htlc_1_ref = HtlcRef {
             channel_id: channel_0,
             htlc_index: 0,
         };
-        let htlc_1 = get_test_htlc(channel_1, ResourceBucketType::Protected, 1000);
+        let htlc_1 = get_test_htlc(channel_1, true, ResourceBucketType::Protected, 1000);
         let htlc_1_risk = tracker
             .params
             .htlc_risk(htlc_1.fee_msat, htlc_1.hold_blocks);
 
-        // Incoming risk is only reflected for channel 1, as it is the outgoing channel.
-        assert!(tracker.add_htlc(htlc_1_ref, htlc_1.clone()).is_ok());
-        assert_eq!(
-            tracker.channel_in_flight_risk(ChannelFilter::OutgoingChannel(1)),
-            htlc_1_risk
-        );
-        assert_eq!(
-            tracker.channel_in_flight_risk(ChannelFilter::OutgoingChannel(0)),
-            0
-        );
-
-        // Balance and count only reflect on outgoing channel.
-        assert_eq!(
-            tracker.bucket_in_flight_msat(channel_1, ResourceBucketType::Protected),
-            htlc_1.outgoing_amt_msat,
-        );
-        assert_eq!(
-            tracker.bucket_in_flight_count(channel_1, ResourceBucketType::Protected),
-            1
-        );
-
-        assert_eq!(
-            tracker.bucket_in_flight_msat(channel_0, ResourceBucketType::General),
-            0
-        );
-        assert_eq!(
-            tracker.bucket_in_flight_count(channel_0, ResourceBucketType::General),
-            0
-        );
-
-        assert!(matches!(
-            tracker.add_htlc(htlc_1_ref, htlc_1).err().unwrap(),
-            ReputationError::ErrDuplicateHtlc(_)
-        ));
-
-        // Unendorsed doesn't contribute to in flight risk, but counted in other tracking, 0 -> 1.
+        // Endorsed htlc contribute to in flight risk and count despite general bucket, 0 -> 1.
         let htlc_2_ref = HtlcRef {
-            channel_id: channel_0,
-            htlc_index: 1,
-        };
-        let mut htlc_2 = get_test_htlc(channel_1, ResourceBucketType::General, 2000);
-        htlc_2.incoming_endorsed = EndorsementSignal::Unendorsed;
-
-        assert!(tracker.add_htlc(htlc_2_ref, htlc_2.clone()).is_ok());
-        assert_eq!(
-            tracker.channel_in_flight_risk(ChannelFilter::OutgoingChannel(channel_1)),
-            htlc_1_risk
-        );
-        assert_eq!(
-            tracker.bucket_in_flight_msat(channel_1, ResourceBucketType::Protected),
-            htlc_2.outgoing_amt_msat,
-        );
-        assert_eq!(
-            tracker.bucket_in_flight_count(channel_0, ResourceBucketType::General),
-            0
-        );
-
-        // Endorsed htlc over different set of channels, 1 -> 2.
-        let htlc_3_ref = HtlcRef {
             channel_id: channel_1,
             htlc_index: 0,
         };
-        let htlc_3 = get_test_htlc(channel_2, ResourceBucketType::General, 150);
-        let htlc_3_risk = tracker
+        let htlc_2 = get_test_htlc(channel_0, true, ResourceBucketType::General, 5000);
+        let htlc_2_risk = tracker
             .params
-            .htlc_risk(htlc_3.fee_msat, htlc_3.hold_blocks);
+            .htlc_risk(htlc_2.fee_msat, htlc_2.hold_blocks);
 
+        // Unendorsed htlc no contribution to in flight risk, 1 -> 2.
+        let htlc_3_ref = HtlcRef {
+            channel_id: channel_1,
+            htlc_index: 1,
+        };
+        let htlc_3 = get_test_htlc(channel_2, false, ResourceBucketType::General, 100000);
+
+        assert!(tracker.add_htlc(htlc_1_ref, htlc_1).is_ok());
+        assert!(tracker.add_htlc(htlc_2_ref, htlc_2).is_ok());
         assert!(tracker.add_htlc(htlc_3_ref, htlc_3).is_ok());
+
+        assert_eq!(
+            tracker.channel_in_flight_risk(ChannelFilter::OutgoingChannel(channel_0)),
+            htlc_2_risk
+        );
+        assert_eq!(
+            tracker.channel_in_flight_risk(ChannelFilter::OutgoingChannel(channel_1)),
+            htlc_1_risk,
+        );
         assert_eq!(
             tracker.channel_in_flight_risk(ChannelFilter::OutgoingChannel(channel_2)),
-            htlc_3_risk
+            0, // Unendorsed does not contribute to risk, so no htlc_3.
+        );
+
+        assert_eq!(
+            tracker.channel_in_flight_risk(ChannelFilter::IncomingChannel(channel_0)),
+            htlc_1_risk,
         );
         assert_eq!(
-            tracker.bucket_in_flight_count(channel_0, ResourceBucketType::General),
-            0
+            tracker.channel_in_flight_risk(ChannelFilter::IncomingChannel(channel_1)),
+            htlc_2_risk, // Unendorsed does not contribute to risk, so no htlc_3.
         );
         assert_eq!(
-            tracker.bucket_in_flight_count(channel_1, ResourceBucketType::General),
-            1
-        );
-        assert_eq!(
-            tracker.bucket_in_flight_count(channel_2, ResourceBucketType::General),
-            1
+            tracker.channel_in_flight_risk(ChannelFilter::IncomingChannel(channel_2)),
+            0,
         );
     }
 
-    /// Tests addition / removal of a successfully settled htlc.
+    /// Tests tracking of in flight counts and liquidity in buckets.
     #[test]
-    fn test_remove_htlc() {
+    fn test_bucket_in_flight() {
         let mut tracker = get_test_manager();
         let channel_0 = 0;
         let channel_1 = 1;
 
+        // Buckets always empty to start.
+        assert_eq!(
+            tracker.bucket_in_flight_count(channel_0, ResourceBucketType::Protected),
+            0
+        );
+        assert_eq!(
+            tracker.bucket_in_flight_count(channel_0, ResourceBucketType::General),
+            0
+        );
+        assert_eq!(
+            tracker.bucket_in_flight_count(channel_1, ResourceBucketType::Protected),
+            0
+        );
+        assert_eq!(
+            tracker.bucket_in_flight_count(channel_1, ResourceBucketType::General),
+            0
+        );
+
+        // Endorsed htlc 0 -> 1.
         let htlc_1_ref = HtlcRef {
             channel_id: channel_0,
             htlc_index: 0,
         };
-        let htlc_1 = get_test_htlc(channel_1, ResourceBucketType::General, 1000);
-        let htlc_2_ref = HtlcRef {
-            channel_id: channel_0,
-            htlc_index: 1,
-        };
-        let htlc_2 = get_test_htlc(channel_1, ResourceBucketType::Protected, 5000);
-
-        tracker.add_htlc(htlc_1_ref, htlc_1.clone()).unwrap();
-        tracker.add_htlc(htlc_2_ref, htlc_2.clone()).unwrap();
-
-        let mut remove_htlc_1 = || tracker.remove_htlc(htlc_1.outgoing_channel_id, htlc_1_ref);
-
-        assert!(remove_htlc_1().is_ok());
-        assert!(matches!(
-            remove_htlc_1().err().unwrap(),
-            ReputationError::ErrForwardNotFound(_, _)
-        ));
+        let htlc_1 = get_test_htlc(channel_1, true, ResourceBucketType::Protected, 1000);
+        assert!(tracker.add_htlc(htlc_1_ref, htlc_1.clone()).is_ok());
 
         assert_eq!(
             tracker.bucket_in_flight_count(channel_1, ResourceBucketType::Protected),
             1
         );
         assert_eq!(
-            tracker.bucket_in_flight_count(channel_1, ResourceBucketType::General),
+            tracker.bucket_in_flight_msat(channel_1, ResourceBucketType::Protected),
+            htlc_1.outgoing_amt_msat,
+        );
+
+        assert_eq!(
+            tracker.bucket_in_flight_count(channel_0, ResourceBucketType::Protected),
             0
+        );
+        assert_eq!(
+            tracker.bucket_in_flight_msat(channel_0, ResourceBucketType::Protected),
+            0,
+        );
+
+        let htlc_2_ref = HtlcRef {
+            channel_id: channel_0,
+            htlc_index: 1,
+        };
+        let mut htlc_2 = get_test_htlc(channel_1, true, ResourceBucketType::Protected, 20);
+        htlc_2.incoming_endorsed = EndorsementSignal::Unendorsed;
+
+        assert!(tracker.add_htlc(htlc_2_ref, htlc_2.clone()).is_ok());
+        assert_eq!(
+            tracker.bucket_in_flight_count(channel_1, ResourceBucketType::Protected),
+            2
+        );
+        assert_eq!(
+            tracker.bucket_in_flight_msat(channel_1, ResourceBucketType::Protected),
+            htlc_1.outgoing_amt_msat + htlc_2.outgoing_amt_msat,
+        );
+
+        // Removing htlc updates accordingly.
+        assert!(tracker
+            .remove_htlc(htlc_1.outgoing_channel_id, htlc_1_ref)
+            .is_ok());
+        assert_eq!(
+            tracker.bucket_in_flight_count(channel_1, ResourceBucketType::Protected),
+            1
+        );
+        assert_eq!(
+            tracker.bucket_in_flight_msat(channel_1, ResourceBucketType::Protected),
+            htlc_2.outgoing_amt_msat,
         );
     }
 }

--- a/ln-resource-mgr/src/incoming_channel.rs
+++ b/ln-resource-mgr/src/incoming_channel.rs
@@ -1,0 +1,101 @@
+use std::time::Instant;
+
+use crate::htlc_manager::InFlightHtlc;
+use crate::{ReputationParams, ResourceBucketType};
+
+/// Tracks information about the usage of the channels when it is utilized as the outgoing direction in a htlc forward.
+#[derive(Debug)]
+pub(super) struct IncomingChannel {
+    params: ReputationParams,
+    /// Tracks the last instant that the incoming channel misused use of congested resources, if any.
+    last_congestion_misuse: Option<Instant>,
+}
+
+impl IncomingChannel {
+    pub(super) fn new(params: ReputationParams) -> Self {
+        Self {
+            params,
+            last_congestion_misuse: None,
+        }
+    }
+
+    /// Returns true if the channel has never misused congestion resources, or sufficient time has passed since last
+    /// abuse (set by ReputationParams.revenue_window, as this is the period we can be jammed for).
+    pub(super) fn no_congestion_misuse(&self, access_ins: Instant) -> bool {
+        if let Some(instant) = self.last_congestion_misuse {
+            access_ins.duration_since(instant) > self.params.revenue_window
+        } else {
+            true
+        }
+    }
+
+    /// Resolves an in flight htlc, updating use of congestion resources to reflect misuse, if any.
+    pub(super) fn remove_incoming_htlc(&mut self, in_flight: &InFlightHtlc, resolved_ins: Instant) {
+        if in_flight.bucket == ResourceBucketType::Congestion
+            && resolved_ins.duration_since(in_flight.added_instant) >= self.params.resolution_period
+        {
+            self.last_congestion_misuse = Some(resolved_ins)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{Duration, Instant};
+
+    use super::IncomingChannel;
+    use crate::htlc_manager::InFlightHtlc;
+    use crate::{EndorsementSignal, ReputationParams, ResourceBucketType};
+
+    #[test]
+    fn test_no_congestion_abuse() {
+        let now = Instant::now();
+        let params = ReputationParams {
+            revenue_window: Duration::from_secs(60 * 60 * 24 * 14),
+            reputation_multiplier: 12,
+            resolution_period: Duration::from_secs(90),
+            expected_block_speed: None,
+        };
+        let mut incoming_channel = IncomingChannel::new(params);
+
+        assert!(incoming_channel.no_congestion_misuse(now));
+
+        // Fast resolving HTLC does not trigger misuse.
+        incoming_channel.remove_incoming_htlc(
+            &InFlightHtlc {
+                outgoing_channel_id: 1,
+                fee_msat: 100,
+                hold_blocks: 40,
+                outgoing_amt_msat: 5000,
+                added_instant: now,
+                incoming_endorsed: EndorsementSignal::Endorsed,
+                bucket: ResourceBucketType::Congestion,
+            },
+            now.checked_add(params.resolution_period / 2).unwrap(),
+        );
+        assert!(incoming_channel.no_congestion_misuse(now));
+
+        // Slow resolving HTLC does trigger misuse.
+        let last_misuse = now.checked_add(params.resolution_period * 2).unwrap();
+        incoming_channel.remove_incoming_htlc(
+            &InFlightHtlc {
+                outgoing_channel_id: 1,
+                fee_msat: 100,
+                hold_blocks: 40,
+                outgoing_amt_msat: 5000,
+                added_instant: now,
+                incoming_endorsed: EndorsementSignal::Endorsed,
+                bucket: ResourceBucketType::Congestion,
+            },
+            last_misuse,
+        );
+        assert!(!incoming_channel.no_congestion_misuse(now));
+
+        // Only recover once the cooldown period has fully passed.
+        let half_recovered = last_misuse.checked_add(params.revenue_window / 2).unwrap();
+        assert!(!incoming_channel.no_congestion_misuse(half_recovered));
+
+        let fully_recovered = last_misuse.checked_add(params.revenue_window).unwrap();
+        assert!(!incoming_channel.no_congestion_misuse(fully_recovered));
+    }
+}

--- a/ln-resource-mgr/src/lib.rs
+++ b/ln-resource-mgr/src/lib.rs
@@ -2,6 +2,7 @@ mod decaying_average;
 pub mod forward_manager;
 pub use htlc_manager::ReputationParams;
 mod htlc_manager;
+mod incoming_channel;
 mod outgoing_channel;
 
 use serde::Serialize;

--- a/ln-resource-mgr/src/lib.rs
+++ b/ln-resource-mgr/src/lib.rs
@@ -13,6 +13,10 @@ use std::time::Instant;
 /// The total supply of bitcoin expressed in millisatoshis.
 const SUPPLY_CAP_MSAT: u64 = 21000000 * 100000000 * 1000;
 
+/// The minimum size of the liquidity limit placed on htlcs that use congestion resources. This is
+/// in place to prevent smaller channels from having unusably small liquidity limits.
+const MINIMUM_CONGESTION_SLOT_LIQUDITY: u64 = 15_000_000;
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ReputationError {
     /// Indicates that the library has encountered an unrecoverable error.
@@ -140,6 +144,8 @@ pub struct AllocationCheck {
     /// The reputation values used to compare the incoming channel's revenue to the outgoing channel's reputation for
     /// the htlc proposed.
     pub reputation_check: ReputationCheck,
+    /// Indicates whether the incoming channel is eligible to consume congestion resources.
+    pub congestion_eligible: bool,
     /// The resources available on the outgoing channel.
     pub resource_check: ResourceCheck,
 }
@@ -148,6 +154,7 @@ pub struct AllocationCheck {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ResourceBucketType {
     Protected,
+    Congestion,
     General,
 }
 
@@ -161,6 +168,9 @@ impl AllocationCheck {
         match self.inner_forwarding_outcome(htlc_amt_msat, incoming_endorsed) {
             Ok(bucket) => match bucket {
                 ResourceBucketType::General => {
+                    ForwardingOutcome::Forward(EndorsementSignal::Unendorsed)
+                }
+                ResourceBucketType::Congestion => {
                     ForwardingOutcome::Forward(EndorsementSignal::Unendorsed)
                 }
                 ResourceBucketType::Protected => {
@@ -182,6 +192,12 @@ impl AllocationCheck {
                 if self.reputation_check.sufficient_reputation() {
                     Ok(ResourceBucketType::Protected)
                 } else {
+                    // If the htlc was endorsed but the peer doesn't have reputation, we consider giving them a shot
+                    // at our reserved congestion resources.
+                    if self.congestion_resources_available(htlc_amt_msat) {
+                        return Ok(ResourceBucketType::Congestion);
+                    }
+
                     Err(FailureReason::NoReputation)
                 }
             }
@@ -197,6 +213,49 @@ impl AllocationCheck {
                 }
             }
         }
+    }
+
+    /// If our general bucket is full, we'll consider a spot in our "congestion" bucket for the forward, because it's
+    /// likely that we're under attack of some kind. This bucket is very strictly controlled -- liquidity is equally
+    /// shared between slots (and no htlc can use more than this allocation) and the sending channel may only utilize
+    /// one slot at a time.
+    fn congestion_resources_available(&self, htlc_amt_msat: u64) -> bool {
+        // If the congestion bucket is completely disabled by setting liquidity or slots to zero,
+        // resources are not available.
+        if self.resource_check.congestion_bucket.slots_available == 0
+            || self
+                .resource_check
+                .congestion_bucket
+                .liquidity_available_msat
+                == 0
+        {
+            return false;
+        }
+
+        if self
+            .resource_check
+            .general_bucket
+            .resources_available(htlc_amt_msat)
+            || !self.congestion_eligible
+            || !self
+                .resource_check
+                .congestion_bucket
+                .resources_available(htlc_amt_msat)
+        {
+            return false;
+        }
+
+        // Divide liquidity in congestion bucket evenly between slots, unless the amount would be less than a
+        // reasonable minimum amount.
+        let liquidity_limit = u64::max(
+            self.resource_check
+                .congestion_bucket
+                .liquidity_available_msat
+                / self.resource_check.congestion_bucket.slots_available as u64,
+            MINIMUM_CONGESTION_SLOT_LIQUDITY,
+        );
+
+        htlc_amt_msat <= liquidity_limit
     }
 }
 
@@ -224,6 +283,7 @@ impl ReputationCheck {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct ResourceCheck {
     pub general_bucket: BucketResources,
+    pub congestion_bucket: BucketResources,
 }
 
 /// Describes the resources currently used in a bucket.
@@ -418,4 +478,150 @@ pub trait ReputationManager {
         &self,
         access_ins: Instant,
     ) -> Result<HashMap<u64, ReputationSnapshot>, ReputationError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        AllocationCheck, BucketResources, EndorsementSignal, FailureReason, ReputationCheck,
+        ResourceBucketType, ResourceCheck, MINIMUM_CONGESTION_SLOT_LIQUDITY,
+    };
+
+    /// Returns an AllocationCheck which is eligible for congestion resources.
+    fn test_congestion_check() -> AllocationCheck {
+        let check = AllocationCheck {
+            reputation_check: ReputationCheck {
+                outgoing_reputation: 0,
+                incoming_revenue: 0,
+                in_flight_total_risk: 0,
+                htlc_risk: 0,
+            },
+            congestion_eligible: true,
+            resource_check: ResourceCheck {
+                general_bucket: BucketResources {
+                    slots_used: 10,
+                    slots_available: 10,
+                    liquidity_used_msat: 0,
+                    liquidity_available_msat: 200_000,
+                },
+                congestion_bucket: BucketResources {
+                    slots_used: 0,
+                    slots_available: 10,
+                    liquidity_used_msat: 0,
+                    liquidity_available_msat: MINIMUM_CONGESTION_SLOT_LIQUDITY * 20,
+                },
+            },
+        };
+        assert!(check.congestion_resources_available(10));
+        check
+    }
+
+    #[test]
+    fn test_congestion_not_eligible() {
+        let mut check = test_congestion_check();
+        check.congestion_eligible = false;
+        assert!(!check.congestion_resources_available(100));
+    }
+
+    #[test]
+    fn test_congestion_general_available() {
+        let mut check = test_congestion_check();
+        check.resource_check.general_bucket.slots_used = 0;
+        assert!(!check.congestion_resources_available(100));
+    }
+
+    #[test]
+    fn test_congestion_bucket_full() {
+        let mut check = test_congestion_check();
+        check.resource_check.congestion_bucket.slots_used =
+            check.resource_check.congestion_bucket.slots_available;
+        assert!(!check.congestion_resources_available(100));
+    }
+
+    #[test]
+    fn test_congestion_htlc_amount() {
+        let check = test_congestion_check();
+        let htlc_limit = check
+            .resource_check
+            .congestion_bucket
+            .liquidity_available_msat
+            / check.resource_check.congestion_bucket.slots_available as u64;
+
+        assert!(check.congestion_resources_available(htlc_limit));
+        assert!(!check.congestion_resources_available(htlc_limit + 1));
+    }
+
+    #[test]
+    fn test_congestion_liquidity() {
+		// Set liquidity such that we'll hit our minimum liquidity allowance.
+        let mut check = test_congestion_check();
+        check
+            .resource_check
+            .congestion_bucket
+            .liquidity_available_msat = MINIMUM_CONGESTION_SLOT_LIQUDITY
+            * check.resource_check.congestion_bucket.slots_available as u64
+            / 2;
+
+		assert!(check.congestion_resources_available(MINIMUM_CONGESTION_SLOT_LIQUDITY));
+		assert!(!check.congestion_resources_available(MINIMUM_CONGESTION_SLOT_LIQUDITY+1));
+    }
+
+    #[test]
+    fn test_inner_forwarding_outcome_congestion() {
+        // Endorsed htlc will be granted access to congestion resources.
+        let check = test_congestion_check();
+        assert!(
+            check
+                .inner_forwarding_outcome(10, EndorsementSignal::Endorsed)
+                .unwrap()
+                == ResourceBucketType::Congestion
+        );
+
+        // Unendorsed htlc will not be granted access to congestion resources.
+        assert!(
+            check
+                .inner_forwarding_outcome(10, EndorsementSignal::Unendorsed)
+                .err()
+                .unwrap()
+                == FailureReason::NoResources,
+        );
+    }
+
+    #[test]
+    fn test_inner_forwarding_outcome_reputation() {
+        let mut check = test_congestion_check();
+        check.reputation_check.outgoing_reputation = 1000;
+        check.resource_check.general_bucket.slots_used = 0;
+
+        // Sufficient reputation and endorsed will go in the protected bucket.
+        assert!(
+            check
+                .inner_forwarding_outcome(10, EndorsementSignal::Endorsed)
+                .unwrap()
+                == ResourceBucketType::Protected,
+        );
+
+        // Sufficient reputation and unendorsed will go in the general bucket.
+        assert!(
+            check
+                .inner_forwarding_outcome(10, EndorsementSignal::Unendorsed)
+                .unwrap()
+                == ResourceBucketType::General,
+        );
+    }
+
+    #[test]
+    fn test_inner_forwarding_outcome_no_reputation() {
+        let mut check = test_congestion_check();
+        check.resource_check.general_bucket.slots_used = 0;
+
+        // Insufficient reputation and endorsed will go in the protected bucket.
+        assert!(
+            check
+                .inner_forwarding_outcome(10, EndorsementSignal::Endorsed)
+                .err()
+                .unwrap()
+                == FailureReason::NoReputation
+        );
+    }
 }

--- a/ln-resource-mgr/src/outgoing_channel.rs
+++ b/ln-resource-mgr/src/outgoing_channel.rs
@@ -26,12 +26,17 @@ pub(super) struct OutgoingChannel {
 
     /// The resources available for htlcs that are not endorsed, or are not sent by a peer with sufficient reputation.
     pub(super) general_bucket: BucketParameters,
+
+    /// The resources available for htlcs that are endorsed from peers that do not have sufficient reputation. This
+    /// bucket is only used when the general bucket is full, and peers are limited to a single slot/liquidity block.
+    pub(super) congestion_bucket: BucketParameters,
 }
 
 impl OutgoingChannel {
     pub(super) fn new(
         params: ReputationParams,
         general_bucket: BucketParameters,
+        congestion_bucket: BucketParameters,
     ) -> Result<Self, ReputationError> {
         if params.reputation_multiplier <= 1 {
             return Err(ReputationError::ErrInvalidMultiplier);
@@ -43,6 +48,7 @@ impl OutgoingChannel {
                 params.revenue_window * params.reputation_multiplier.into(),
             ),
             general_bucket,
+            congestion_bucket,
         })
     }
 
@@ -112,6 +118,10 @@ mod tests {
             BucketParameters {
                 slot_count: 100,
                 liquidity_msat: 100_000,
+            },
+            BucketParameters {
+                slot_count: 30,
+                liquidity_msat: 50_000,
             },
         )
         .unwrap()

--- a/ln-simln-jamming/src/main.rs
+++ b/ln-simln-jamming/src/main.rs
@@ -145,8 +145,10 @@ async fn main() -> Result<(), BoxError> {
             resolution_period: Duration::from_secs(90),
             expected_block_speed: Some(Duration::from_secs(10 * 60)),
         },
-        general_slot_portion: 50,
-        general_liquidity_portion: 50,
+        general_slot_portion: 30,
+        general_liquidity_portion: 30,
+        congestion_slot_portion: 20,
+        congestion_liquidity_portion: 20,
     };
 
     // Create a writer to store results for nodes that we care about.

--- a/ln-simln-jamming/src/reputation_interceptor.rs
+++ b/ln-simln-jamming/src/reputation_interceptor.rs
@@ -852,8 +852,10 @@ mod tests {
                 resolution_period: Duration::from_secs(90),
                 expected_block_speed: None,
             },
-            general_slot_portion: 50,
-            general_liquidity_portion: 50,
+            general_slot_portion: 30,
+            general_liquidity_portion: 30,
+            congestion_slot_portion: 20,
+            congestion_liquidity_portion: 20,
         };
 
         let edges = vec![

--- a/ln-simln-jamming/src/test_utils.rs
+++ b/ln-simln-jamming/src/test_utils.rs
@@ -74,12 +74,19 @@ pub fn test_allocation_check(forward_succeeds: bool) -> AllocationCheck {
             in_flight_total_risk: 0,
             htlc_risk: 0,
         },
+        congestion_eligible: true,
         resource_check: ResourceCheck {
             general_bucket: BucketResources {
                 slots_used: 0,
                 slots_available: 10,
                 liquidity_used_msat: 0,
                 liquidity_available_msat: 100_000,
+            },
+            congestion_bucket: BucketResources {
+                slots_used: 0,
+                slots_available: 5,
+                liquidity_used_msat: 0,
+                liquidity_available_msat: 50_000,
             },
         },
     };


### PR DESCRIPTION
When our general resources are full, it's likely that we're under attack of some kind.

This PR adds a "congestion" bucket which is only used when general is saturated. Nodes may use resources in this bucket with the following restrictions:
* They only consume one slot at a time, and htlcs may be no larger than `bucket liquidity / bucket slots`
* In the last 2 weeks, they have not used the congestion resources for a htlc that was held for > 90s
* The incoming HTLC was endorsed

This bucket attempts to give honest peers a shot at resources, even if they don't have reputation. It can't be easily abused by attackers because usage is very limited (one congestion slot per inbound across all of our outbound), and to try abuse it through another peer the attacker has to gain reputation with the peer first (because their htlc wont' be endorsed otherwise).