### PR TITLE
Extend simulation to utilize congestion and recover

### DIFF
--- a/ln-simln-jamming/src/main.rs
+++ b/ln-simln-jamming/src/main.rs
@@ -91,12 +91,12 @@ async fn main() -> Result<(), BoxError> {
         })
         .collect();
 
-    let jammed_peers = target_channels
+    let jammed_peers: Vec<(u64, PublicKey)> = target_channels
         .iter()
         .filter_map(|(scid, channel)| {
             if channel.channel_type == TargetChannelType::Peer {
                 let scid = *scid;
-                Some((channel.peer_pubkey, scid.into()))
+                Some((scid.into(), channel.peer_pubkey))
             } else {
                 None
             }
@@ -188,7 +188,7 @@ async fn main() -> Result<(), BoxError> {
         ReputationInterceptor::new_with_bootstrap(
             forward_params,
             &sim_network,
-            jammed_peers,
+            &jammed_peers,
             &bootstrap,
             clock.clone(),
             Some(results_writer),

--- a/ln-simln-jamming/src/main.rs
+++ b/ln-simln-jamming/src/main.rs
@@ -93,12 +93,15 @@ async fn main() -> Result<(), BoxError> {
 
     let jammed_peers: Vec<(u64, PublicKey)> = target_channels
         .iter()
-        .filter_map(|(scid, channel)| {
+        .flat_map(|(scid, channel)| {
             if channel.channel_type == TargetChannelType::Peer {
                 let scid = *scid;
-                Some((scid.into(), channel.peer_pubkey))
+                vec![
+                    (scid.into(), channel.peer_pubkey),
+                    (scid.into(), target_pubkey),
+                ]
             } else {
-                None
+                vec![]
             }
         })
         .collect();

--- a/ln-simln-jamming/src/main.rs
+++ b/ln-simln-jamming/src/main.rs
@@ -225,15 +225,10 @@ async fn main() -> Result<(), BoxError> {
         select! {
             _ = attack_listener.clone() => return,
             _ = attack_clock.sleep(interval) => {
-                match attack_interceptor_1
-                    .get_target_pairs(
-                        target_pubkey,
-                        TargetChannelType::Attacker,
-                        InstantClock::now(&*attack_clock),
-                    )
+                match attack_interceptor_1.get_reputation_status(InstantClock::now(&*attack_clock))
                 .await {
                     Ok(rep) => {
-                        if !rep.iter().any(|pair| pair.outgoing_reputation(reputation_threshold)) {
+                        if !rep.attacker_reputation.iter().any(|pair| pair.outgoing_reputation(reputation_threshold)) {
                             log::error!("Attacker has no more reputation with the target");
                             attack_shutdown.trigger();
                             return;

--- a/ln-simln-jamming/src/main.rs
+++ b/ln-simln-jamming/src/main.rs
@@ -338,6 +338,7 @@ async fn main() -> Result<(), BoxError> {
         &snapshot,
         &start_reputation,
         &end_reputation,
+        jammed_peers.len(),
     )?;
 
     Ok(())
@@ -484,6 +485,7 @@ fn check_reputation_status(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn write_simulation_summary(
     data_dir: PathBuf,
     reputation_margin_msat: u64,
@@ -492,6 +494,7 @@ fn write_simulation_summary(
     revenue: &RevenueSnapshot,
     start_reputation: &NetworkReputation,
     end_reputation: &NetworkReputation,
+    general_jammed: usize,
 ) -> Result<(), BoxError> {
     let file = OpenOptions::new()
         .append(true)
@@ -562,6 +565,10 @@ fn write_simulation_summary(
         "Target end reputation (pairs): {}/{}",
         end_count.1,
         end_reputation.target_reputation.len()
+    )?;
+    writeln!(
+        writer,
+        "Attacker general jammed {general_jammed} edges (directional)",
     )?;
     writer.flush()?;
 

--- a/ln-simln-jamming/src/reputation_interceptor.rs
+++ b/ln-simln-jamming/src/reputation_interceptor.rs
@@ -199,7 +199,7 @@ where
         interceptor.bootstrap_network_history(bootstrap).await?;
 
         // After the network has been bootstrapped, we can go ahead and general jam required channels.
-        for (channel, pubkey) in general_jammed.into_iter() {
+        for (channel, pubkey) in general_jammed.iter() {
             interceptor
                 .network_nodes
                 .lock()

--- a/ln-simln-jamming/src/reputation_interceptor.rs
+++ b/ln-simln-jamming/src/reputation_interceptor.rs
@@ -188,7 +188,7 @@ where
     pub async fn new_with_bootstrap(
         params: ForwardManagerParams,
         edges: &[NetworkParser],
-        general_jammed: HashMap<PublicKey, u64>,
+        general_jammed: &[(u64, PublicKey)],
         bootstrap: &BoostrapRecords,
         clock: Arc<dyn InstantClock + Send + Sync>,
         results: Option<Arc<Mutex<R>>>,
@@ -199,7 +199,7 @@ where
         interceptor.bootstrap_network_history(bootstrap).await?;
 
         // After the network has been bootstrapped, we can go ahead and general jam required channels.
-        for (pubkey, channel) in general_jammed.iter() {
+        for (channel, pubkey) in general_jammed.into_iter() {
             interceptor
                 .network_nodes
                 .lock()
@@ -954,7 +954,7 @@ mod tests {
             ReputationInterceptor::new_with_bootstrap(
                 params,
                 &edges,
-                HashMap::from([(edges[1].node_1.pubkey, bob_to_carol)]),
+                &[(bob_to_carol, edges[1].node_1.pubkey)],
                 &BoostrapRecords {
                     forwards: boostrap,
                     last_timestamp_nanos: 1_000_000,

--- a/ln-simln-jamming/src/sink_interceptor.rs
+++ b/ln-simln-jamming/src/sink_interceptor.rs
@@ -231,11 +231,9 @@ impl<C: InstantClock + Clock, R: Interceptor + ReputationMonitor> SinkIntercepto
             return;
         }
 
-        // Get maximum hold time assuming 10 minute blocks.
-        // TODO: this is actually the current height less the expiry, but we don't have the concept of height here.
-        let max_hold_secs = Duration::from_secs(
-            ((req.incoming_expiry_height - req.outgoing_expiry_height) * 10 * 60).into(),
-        );
+        // Get maximum hold time assuming 10 minute blocks, assuming a zero block height (simulator doesn't track
+        // height).
+        let max_hold_secs = Duration::from_secs((req.incoming_expiry_height * 10 * 60).into());
 
         log::info!(
             "HTLC from target -> attacker endorsed, holding for {:?}: {}",

--- a/ln-simln-jamming/src/sink_interceptor.rs
+++ b/ln-simln-jamming/src/sink_interceptor.rs
@@ -338,13 +338,30 @@ impl<C: InstantClock + Clock, R: Interceptor + ReputationMonitor> Interceptor
 {
     /// Implemented by HTLC interceptors that provide input on the resolution of HTLCs forwarded in the simulation.
     async fn intercept_htlc(&self, req: InterceptRequest) {
-        // Intercept payments from target -> attacker.
-        if let Some(target_chan) = self.target_channels.get(&req.incoming_htlc.channel_id) {
-            if *target_chan == TargetChannelType::Attacker
-                && req.forwarding_node == self.attacker_pubkey
-            {
+        // Intercept payments on the attacking node. If they're incoming from the target, jam them. If they're outgoing
+        // to the target, just drop them to prevent them from earning revenue. Other payments are ok, they help the
+        // attacker be a link that other nodes want to forward through them.
+        if req.forwarding_node == self.attacker_pubkey {
+            if let Some(target_chan) = self.target_channels.get(&req.incoming_htlc.channel_id) {
+                assert!(*target_chan == TargetChannelType::Attacker);
+
                 self.intercept_attacker_incoming(req).await;
                 return;
+            }
+
+            if let Some(outgoing_scid) = req.outgoing_channel_id {
+                if let Some(target_chan) = self.target_channels.get(&outgoing_scid) {
+                    assert!(*target_chan == TargetChannelType::Attacker);
+
+                    send_intercept_result!(
+                        req,
+                        Ok(Err(ForwardingError::InterceptorError(
+                            "attacker failing".into()
+                        ))),
+                        self.shutdown
+                    );
+                    return;
+                }
             }
         }
 


### PR DESCRIPTION
Depends on #32 

Some changes to test how our reputation bounces back with congestion resources in play:
- General jam `target -> peer` edges, so that target needs to use congestion resources
- Only shutdown when attacker has lost reputation *and* the target's reputation has recovered to similar to start
  - Reputations couldn't be ruined, and the attack failed
  - Reputations bounded back, so recovery is working
- Revenue check for shutdown remains unchanged
- Hold HTLCs for full incoming expiry