### PR TITLE
prefactor: prepare for pulling attack out into module

### DIFF
--- a/ln-simln-jamming/src/lib.rs
+++ b/ln-simln-jamming/src/lib.rs
@@ -1,6 +1,13 @@
-use ln_resource_mgr::EndorsementSignal;
+use bitcoin::secp256k1::PublicKey;
+use ln_resource_mgr::{ChannelSnapshot, EndorsementSignal};
 use simln_lib::sim_node::CustomRecords;
+use std::collections::HashMap;
 use std::error::Error;
+use std::sync::Arc;
+use std::time::Instant;
+use tokio::sync::Mutex;
+
+use self::reputation_interceptor::ReputationMonitor;
 
 pub mod analysis;
 pub mod attack_interceptor;
@@ -39,5 +46,294 @@ pub fn records_from_endorsement(endorsement: EndorsementSignal) -> CustomRecords
             records.insert(ENDORSEMENT_TYPE, vec![1]);
             records
         }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub struct NetworkReputation {
+    pub target_reputation: usize,
+    pub target_pair_count: usize,
+    pub attacker_reputation: usize,
+    pub attacker_pair_count: usize,
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn get_network_reputation<R: ReputationMonitor>(
+    reputation_monitor: Arc<Mutex<R>>,
+    target_pubkey: PublicKey,
+    attacker_pubkey: PublicKey,
+    target_channels: &HashMap<u64, PublicKey>,
+    risk_margin: u64,
+    access_ins: Instant,
+) -> Result<NetworkReputation, BoxError> {
+    let reputation_monitor_lock = reputation_monitor.lock().await;
+    let target_channels_snapshot = reputation_monitor_lock
+        .list_channels(target_pubkey, access_ins)
+        .await?;
+
+    let mut network_reputation = NetworkReputation {
+        attacker_reputation: 0,
+        attacker_pair_count: 0,
+        target_pair_count: 0,
+        target_reputation: 0,
+    };
+
+    for (scid, pubkey) in target_channels {
+        // If we've got a chanel with the attacker, we want to get a snapshot of what its reputation is with the
+        // target node. Otherwise, we'll get a snapshot of what the target node's reputation is with its peers.
+        let (channels, is_attacker) = if *pubkey == attacker_pubkey {
+            (&target_channels_snapshot, true)
+        } else {
+            (
+                &reputation_monitor_lock
+                    .list_channels(*pubkey, access_ins)
+                    .await?,
+                false,
+            )
+        };
+
+        let repuation_pairs = count_reputation_pairs(channels, *scid, risk_margin)?;
+        let total_paris = channels.len() - 1;
+
+        if is_attacker {
+            network_reputation.attacker_reputation += repuation_pairs;
+            network_reputation.attacker_pair_count += total_paris;
+        } else {
+            network_reputation.target_reputation += repuation_pairs;
+            network_reputation.target_pair_count += total_paris;
+        }
+    }
+
+    log::info!(
+        "Attacker has {} out of {} pairs with reputation",
+        network_reputation.attacker_reputation,
+        network_reputation.attacker_pair_count,
+    );
+
+    log::info!(
+        "Target has {}/{} pairs with reputation with its peers",
+        network_reputation.target_reputation,
+        network_reputation.target_pair_count,
+    );
+
+    Ok(network_reputation)
+}
+
+/// Counts the number of pairs that the outgoing channel has reputation for.
+fn count_reputation_pairs(
+    channels: &HashMap<u64, ChannelSnapshot>,
+    outgoing_channel: u64,
+    risk_margin: u64,
+) -> Result<usize, BoxError> {
+    let outgoing_channel_snapshot = channels
+        .get(&outgoing_channel)
+        .ok_or(format!("outgoing channel: {} not found", outgoing_channel))?;
+
+    Ok(channels
+        .iter()
+        .filter(|(scid, snapshot)| {
+            **scid != outgoing_channel
+                && outgoing_channel_snapshot.outgoing_reputation
+                    >= snapshot.bidirectional_revenue + risk_margin as i64
+        })
+        .count())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::reputation_interceptor::{HtlcAdd, ReputationMonitor};
+    use crate::test_utils::get_random_keypair;
+    use crate::{count_reputation_pairs, get_network_reputation};
+    use crate::{BoxError, NetworkReputation};
+    use async_trait::async_trait;
+    use bitcoin::secp256k1::PublicKey;
+    use ln_resource_mgr::{AllocationCheck, ChannelSnapshot, ReputationError};
+    use mockall::mock;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use std::time::Instant;
+    use tokio::sync::Mutex;
+
+    mock! {
+        Monitor{}
+
+        #[async_trait]
+        impl ReputationMonitor for Monitor{
+            async fn list_channels(&self, node: PublicKey, access_ins: Instant) -> Result<HashMap<u64, ChannelSnapshot>, BoxError>;
+            async fn check_htlc_outcome(&self,htlc_add: HtlcAdd) -> Result<AllocationCheck, ReputationError>;
+        }
+    }
+
+    /// Tests counting the number of pairs that an outgoing channel has good reputation on. Uses a zero risk margin
+    /// to simplify test values.
+    #[test]
+    fn test_count_reputation_pairs() {
+        let channels = vec![
+            (
+                0,
+                ChannelSnapshot {
+                    outgoing_reputation: 100_000,
+                    bidirectional_revenue: 20_000,
+                },
+            ),
+            (
+                1,
+                ChannelSnapshot {
+                    outgoing_reputation: 45_000,
+                    bidirectional_revenue: 50_000,
+                },
+            ),
+            (
+                2,
+                ChannelSnapshot {
+                    outgoing_reputation: 15_000,
+                    bidirectional_revenue: 80_000,
+                },
+            ),
+        ]
+        .into_iter()
+        .collect();
+
+        // Channel not found.
+        assert!(count_reputation_pairs(&channels, 999, 0).is_err());
+
+        assert_eq!(count_reputation_pairs(&channels, 0, 0).unwrap(), 2);
+        assert_eq!(count_reputation_pairs(&channels, 1, 0).unwrap(), 1);
+        assert_eq!(count_reputation_pairs(&channels, 2, 0).unwrap(), 0);
+    }
+
+    /// Tests fetching network reputation pairs for the following topology:
+    ///
+    /// --(4) --+
+    ///         |
+    /// --(5)-- P1 --(1) ---+
+    ///				        |
+    /// --(6)-- P2 --(2) -- Target --(0) -- Attacker
+    ///				        |
+    ///         P3 --(3) ---+
+    #[tokio::test]
+    async fn test_get_network_reputation() {
+        let mut mock_monitor = MockMonitor::new();
+        let now = Instant::now();
+
+        let target_pubkey = get_random_keypair().1;
+        let attacker_pubkey = get_random_keypair().1;
+
+        let peer_1 = get_random_keypair().1;
+        let peer_2 = get_random_keypair().1;
+        let peer_3 = get_random_keypair().1;
+        let target_channels: HashMap<u64, PublicKey> =
+            vec![(0, attacker_pubkey), (1, peer_1), (2, peer_2), (3, peer_3)]
+                .into_iter()
+                .collect();
+
+        mock_monitor
+            .expect_list_channels()
+            .returning(move |pubkey, _| {
+                let data = if pubkey == target_pubkey {
+                    vec![
+                        (
+                            0,
+                            ChannelSnapshot {
+                                outgoing_reputation: 100,
+                                bidirectional_revenue: 15,
+                            },
+                        ),
+                        (
+                            1,
+                            ChannelSnapshot {
+                                outgoing_reputation: 150,
+                                bidirectional_revenue: 110,
+                            },
+                        ),
+                        (
+                            2,
+                            ChannelSnapshot {
+                                outgoing_reputation: 200,
+                                bidirectional_revenue: 90,
+                            },
+                        ),
+                        (
+                            3,
+                            ChannelSnapshot {
+                                outgoing_reputation: 75,
+                                bidirectional_revenue: 100,
+                            },
+                        ),
+                    ]
+                } else if pubkey == peer_1 {
+                    vec![
+                        (
+                            1,
+                            ChannelSnapshot {
+                                outgoing_reputation: 500,
+                                bidirectional_revenue: 15,
+                            },
+                        ),
+                        (
+                            4,
+                            ChannelSnapshot {
+                                outgoing_reputation: 150,
+                                bidirectional_revenue: 600,
+                            },
+                        ),
+                        (
+                            5,
+                            ChannelSnapshot {
+                                outgoing_reputation: 200,
+                                bidirectional_revenue: 250,
+                            },
+                        ),
+                    ]
+                } else if pubkey == peer_2 {
+                    vec![
+                        (
+                            2,
+                            ChannelSnapshot {
+                                outgoing_reputation: 1000,
+                                bidirectional_revenue: 50,
+                            },
+                        ),
+                        (
+                            6,
+                            ChannelSnapshot {
+                                outgoing_reputation: 350,
+                                bidirectional_revenue: 800,
+                            },
+                        ),
+                    ]
+                } else if pubkey == peer_3 {
+                    vec![(
+                        3,
+                        ChannelSnapshot {
+                            outgoing_reputation: 1000,
+                            bidirectional_revenue: 50,
+                        },
+                    )]
+                } else {
+                    panic!("unexpected pubkey");
+                };
+
+                Ok(data.into_iter().collect())
+            });
+
+        let expected_reputation = NetworkReputation {
+            target_reputation: 2,
+            target_pair_count: 3,
+            attacker_reputation: 2,
+            attacker_pair_count: 3,
+        };
+        let network_reputation = get_network_reputation(
+            Arc::new(Mutex::new(mock_monitor)),
+            target_pubkey,
+            attacker_pubkey,
+            &target_channels,
+            0,
+            now,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(expected_reputation, network_reputation);
     }
 }

--- a/ln-simln-jamming/src/main.rs
+++ b/ln-simln-jamming/src/main.rs
@@ -23,9 +23,10 @@ use std::collections::HashMap;
 use std::fs::{self, OpenOptions};
 use std::io::{BufWriter, Write};
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::Duration;
 use tokio::select;
+use tokio::sync::Mutex;
 use tokio::task::JoinSet;
 
 #[derive(Serialize, Deserialize)]
@@ -174,7 +175,7 @@ async fn main() -> Result<(), BoxError> {
             select! {
                 _ = results_listener.clone() => return,
                 _ = results_clock.sleep(interval) => {
-                      if let Err(e) = results_writer_1.lock().unwrap().write(){
+                      if let Err(e) = results_writer_1.lock().await.write(){
                         log::error!("Error writing results: {e}");
                         results_shutdown.trigger();
                         return

--- a/ln-simln-jamming/src/main.rs
+++ b/ln-simln-jamming/src/main.rs
@@ -17,7 +17,7 @@ use simln_lib::interceptors::LatencyIntercepor;
 use simln_lib::sim_node::{Interceptor, SimulatedChannel};
 use simln_lib::{NetworkParser, Simulation, SimulationCfg};
 use simple_logger::SimpleLogger;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs::{self, OpenOptions};
 use std::io::{BufWriter, Write};
 use std::path::PathBuf;
@@ -123,7 +123,6 @@ async fn main() -> Result<(), BoxError> {
         )
         .into());
     }
-    let target_attacker_scid = *target_to_attacker.first().unwrap();
 
     // Pull history that bootstraps the simulation in a network with the attacker's channels present, filter to only
     // have attacker forwards present when the and calculate revenue for the target node during this bootstrap period.
@@ -131,7 +130,7 @@ async fn main() -> Result<(), BoxError> {
     let bootstrap = get_history_for_bootstrap(
         cli.attacker_bootstrap,
         unfiltered_history,
-        target_attacker_scid,
+        HashSet::from_iter(target_to_attacker.into_iter()),
     )?;
     let bootstrap_revenue = bootstrap.forwards.iter().fold(0, |acc, item| {
         if item.forwarding_node == target_pubkey {

--- a/ln-simln-jamming/src/main.rs
+++ b/ln-simln-jamming/src/main.rs
@@ -3,14 +3,12 @@ use clap::Parser;
 use ln_resource_mgr::forward_manager::ForwardManagerParams;
 use ln_resource_mgr::ReputationParams;
 use ln_simln_jamming::analysis::BatchForwardWriter;
-use ln_simln_jamming::attack_interceptor::{
-    AttackInterceptor, NetworkReputation, TargetChannelType,
-};
+use ln_simln_jamming::attack_interceptor::{AttackInterceptor, TargetChannelType};
 use ln_simln_jamming::clock::InstantClock;
 use ln_simln_jamming::parsing::{get_history_for_bootstrap, history_from_file, Cli};
 use ln_simln_jamming::reputation_interceptor::ReputationInterceptor;
 use ln_simln_jamming::revenue_interceptor::{RevenueInterceptor, RevenueSnapshot};
-use ln_simln_jamming::BoxError;
+use ln_simln_jamming::{get_network_reputation, BoxError, NetworkReputation};
 use log::LevelFilter;
 use serde::{Deserialize, Serialize};
 use simln_lib::clock::Clock;
@@ -61,15 +59,31 @@ async fn main() -> Result<(), BoxError> {
     let target_pubkey = find_pubkey_by_alias(&cli.target_alias, &sim_network)?;
     let attacker_pubkey = find_pubkey_by_alias(&cli.attacker_alias, &sim_network)?;
 
-    let target_channels =
-        get_target_channel_descriptions(&sim_network, attacker_pubkey, target_pubkey);
+    let target_channels: HashMap<u64, (PublicKey, String)> = sim_network
+        .iter()
+        .filter_map(|channel| {
+            if channel.node_1.pubkey == target_pubkey {
+                Some((
+                    channel.scid.into(),
+                    (channel.node_2.pubkey, channel.node_2.alias.clone()),
+                ))
+            } else if channel.node_2.pubkey == target_pubkey {
+                Some((
+                    channel.scid.into(),
+                    (channel.node_1.pubkey, channel.node_1.alias.clone()),
+                ))
+            } else {
+                None
+            }
+        })
+        .collect();
 
     // We want to monitor results for all non-attacking nodes and the target node.
     let mut monitor_nodes = target_channels
         .iter()
-        .filter_map(|(_, channel)| {
-            if channel.channel_type == TargetChannelType::Peer {
-                return Some((channel.peer_pubkey, channel.alias.clone()));
+        .filter_map(|(_, (pk, alias))| {
+            if *pk != attacker_pubkey {
+                return Some((*pk, alias.clone()));
             }
 
             None
@@ -78,31 +92,25 @@ async fn main() -> Result<(), BoxError> {
     monitor_nodes.push((target_pubkey, cli.target_alias.to_string()));
 
     // Create a map of all the target's channels, and a vec of its non-attacking peers.
-    let target_channel_map = target_channels
-        .values()
-        .map(|channel| (channel.scid, channel.channel_type.clone()))
-        .collect();
-
-    let honest_peers = target_channels
+    let target_channel_map: HashMap<ShortChannelID, TargetChannelType> = target_channels
         .iter()
-        .filter_map(|(_, channel)| {
-            if channel.channel_type == TargetChannelType::Peer {
-                Some(channel.peer_pubkey)
-            } else {
-                None
-            }
+        .map(|(scid, (pk, _))| {
+            (
+                ShortChannelID::from(*scid),
+                if *pk == attacker_pubkey {
+                    TargetChannelType::Attacker
+                } else {
+                    TargetChannelType::Peer
+                },
+            )
         })
         .collect();
 
     let jammed_peers: Vec<(u64, PublicKey)> = target_channels
         .iter()
-        .flat_map(|(scid, channel)| {
-            if channel.channel_type == TargetChannelType::Peer {
-                let scid = *scid;
-                vec![
-                    (scid.into(), channel.peer_pubkey),
-                    (scid.into(), target_pubkey),
-                ]
+        .flat_map(|(scid, (pk, _))| {
+            if *pk != attacker_pubkey {
+                vec![(*scid, *pk), (*scid, target_pubkey)]
             } else {
                 vec![]
             }
@@ -111,8 +119,13 @@ async fn main() -> Result<(), BoxError> {
 
     let target_to_attacker: Vec<u64> = target_channels
         .iter()
-        .filter(|(_, channel)| channel.channel_type == TargetChannelType::Attacker)
-        .map(|(scid, _)| u64::from(*scid))
+        .filter_map(|(scid, (pk, _))| {
+            if *pk == attacker_pubkey {
+                Some(*scid)
+            } else {
+                None
+            }
+        })
         .collect();
 
     if target_to_attacker.len() != 1 {
@@ -122,6 +135,7 @@ async fn main() -> Result<(), BoxError> {
         )
         .into());
     }
+    let target_attacker_scid = *target_to_attacker.first().unwrap();
 
     // Pull history that bootstraps the simulation in a network with the attacker's channels present, filter to only
     // have attacker forwards present when the and calculate revenue for the target node during this bootstrap period.
@@ -129,7 +143,7 @@ async fn main() -> Result<(), BoxError> {
     let bootstrap = get_history_for_bootstrap(
         cli.attacker_bootstrap,
         unfiltered_history,
-        *target_to_attacker.first().unwrap(),
+        target_attacker_scid,
     )?;
     let bootstrap_revenue = bootstrap.forwards.iter().fold(0, |acc, item| {
         if item.forwarding_node == target_pubkey {
@@ -144,6 +158,7 @@ async fn main() -> Result<(), BoxError> {
         Arc::new(LatencyIntercepor::new_poisson(150.0)?);
 
     let clock = Arc::new(SimulationClock::new(cli.clock_speedup)?);
+    let now = InstantClock::now(&*clock);
     let forward_params = ForwardManagerParams {
         reputation_params: ReputationParams {
             revenue_window: Duration::from_secs(cli.revenue_window_seconds),
@@ -162,7 +177,7 @@ async fn main() -> Result<(), BoxError> {
         cli.results_dir.clone(),
         &monitor_nodes,
         cli.result_batch_size,
-        InstantClock::now(&*clock),
+        now,
     )));
 
     let results_writer_1 = results_writer.clone();
@@ -202,40 +217,49 @@ async fn main() -> Result<(), BoxError> {
         attacker_pubkey,
         target_pubkey,
         target_channel_map,
-        honest_peers,
-        reputation_interceptor,
+        reputation_interceptor.clone(),
         listener.clone(),
         shutdown.clone(),
     );
 
+    // Reputation is assessed for a channel pair and a specific HTLC that's being proposed. To assess whether pairs
+    // have reputation, we'll use LND's default fee policy to get the HTLC risk for our configured htlc size and hold
+    // time.
+    let risk_margin = forward_params.htlc_opportunity_cost(
+        1000 + (0.0001 * cli.reputation_margin_msat as f64) as u64,
+        cli.reputation_margin_expiry_blocks,
+    );
+
     // Do some preliminary checks on our reputation state - there isn't much point in running if we haven't built up
     // some reputation.
-    let start_reputation = attack_interceptor
-        .get_reputation_status(InstantClock::now(&*clock))
-        .await?;
+    let start_reputation = get_network_reputation(
+        reputation_interceptor.clone(),
+        target_pubkey,
+        attacker_pubkey,
+        &target_channels
+            .iter()
+            .map(|(scid, (pk, _))| (*scid, *pk))
+            .collect(),
+        risk_margin,
+        now,
+    )
+    .await?;
 
-    check_reputation_status(&cli, &forward_params, &start_reputation, true)?;
-
-    let (_, start_target_reputation_count) = get_reputation_count(
-        cli.reputation_margin_msat,
-        cli.reputation_margin_expiry_blocks,
-        &forward_params,
-        &start_reputation,
-    );
+    check_reputation_status(&cli, &start_reputation)?;
 
     let attack_interceptor = Arc::new(attack_interceptor);
 
     // Spawn a task that will trigger shutdown of the simulation if the attacker loses reputation provided that the
     // target is at similar reputation to the start of the simulation. This is a somewhat crude check, because we're
     // only looking at the count of peers with reputation not the actual pairs.
-    let attack_interceptor_1 = attack_interceptor.clone();
+    let reputation_interceptor_1 = reputation_interceptor.clone();
     let attack_clock = clock.clone();
     let attack_listener = listener.clone();
     let attack_shutdown = shutdown.clone();
-    let reputation_threshold = forward_params.htlc_opportunity_cost(
-        get_reputation_margin_fee(cli.reputation_margin_msat),
-        cli.reputation_margin_expiry_blocks,
-    );
+    let target_channels_1 = target_channels
+        .iter()
+        .map(|(scid, (pk, _))| (*scid, *pk))
+        .collect();
 
     tasks.spawn(async move {
     let interval = Duration::from_secs(cli.attacker_poll_interval_seconds);
@@ -243,21 +267,27 @@ async fn main() -> Result<(), BoxError> {
         select! {
             _ = attack_listener.clone() => return,
             _ = attack_clock.sleep(interval) => {
-                match attack_interceptor_1.get_reputation_status(InstantClock::now(&*attack_clock))
-                .await {
+               let status = get_network_reputation(
+                    reputation_interceptor_1.clone(),
+                    target_pubkey,
+					attacker_pubkey,
+					&target_channels_1,
+					risk_margin,
+                    InstantClock::now(&*attack_clock),
+                ).await;
+                match status {
                     Ok(rep) => {
-                        if !rep.attacker_reputation.iter().any(|pair| pair.outgoing_reputation(reputation_threshold)) {
+                        if rep.attacker_reputation == 0 {
                             log::error!("Attacker has no more reputation with the target");
 
-							let target_reputation = rep.target_reputation.iter().filter(|pair| pair.outgoing_reputation(reputation_threshold)).count();
-							if target_reputation >= start_target_reputation_count {
-								log::error!("Attacker has no more reputation with target and the target's reputation is similar to simulation start");
-								attack_shutdown.trigger();
-								return;
-							}
+                            if rep.target_reputation >= start_reputation.target_reputation {
+                                log::error!("Attacker has no more reputation with target and the target's reputation is similar to simulation start");
+                                attack_shutdown.trigger();
+                                return;
+                            }
 
-							log::info!("Attacker has no more reputation with target but target's reputation is worse than start count ({target_reputation} < {start_target_reputation_count}), continuing simulation to monitor recovery"); 
-						}
+                            log::info!("Attacker has no more reputation with target but target's reputation is worse than start count ({} < {}), continuing simulation to monitor recovery", rep.target_reputation, start_reputation.target_reputation); 
+                        }
                     },
                     Err(e) => {
                         log::error!("Error checking attacker reputation: {e}");
@@ -331,16 +361,22 @@ async fn main() -> Result<(), BoxError> {
     graph.lock().await.wait_for_shutdown().await;
 
     // Write start and end state to a summary file.
-    let end_reputation = attack_interceptor
-        .get_reputation_status(InstantClock::now(&*clock))
-        .await?;
+    let end_reputation = get_network_reputation(
+        reputation_interceptor,
+        target_pubkey,
+        attacker_pubkey,
+        &target_channels
+            .iter()
+            .map(|(scid, (pk, _))| (*scid, *pk))
+            .collect(),
+        risk_margin,
+        InstantClock::now(&*clock),
+    )
+    .await?;
 
     let snapshot = revenue_interceptor.get_revenue_difference().await;
     write_simulation_summary(
         cli.results_dir,
-        cli.reputation_margin_msat,
-        cli.reputation_margin_expiry_blocks,
-        &forward_params,
         &snapshot,
         &start_reputation,
         &end_reputation,
@@ -348,55 +384,6 @@ async fn main() -> Result<(), BoxError> {
     )?;
 
     Ok(())
-}
-
-struct TargetChannel {
-    /// The public key of the target's counterparty.
-    peer_pubkey: PublicKey,
-    scid: ShortChannelID,
-    alias: String,
-    channel_type: TargetChannelType,
-}
-
-fn get_target_channel_descriptions(
-    edges: &[NetworkParser],
-    attacker_pubkey: PublicKey,
-    target_pubkey: PublicKey,
-) -> HashMap<ShortChannelID, TargetChannel> {
-    let mut target_channels = HashMap::new();
-
-    for channel in edges.iter() {
-        let node_1_target = channel.node_1.pubkey == target_pubkey;
-        let node_2_target = channel.node_2.pubkey == target_pubkey;
-
-        if !(node_1_target || node_2_target) {
-            continue;
-        }
-
-        let chan_policy = if node_1_target {
-            &channel.node_2
-        } else {
-            &channel.node_1
-        };
-
-        let channel_type = if chan_policy.pubkey == attacker_pubkey {
-            TargetChannelType::Attacker
-        } else {
-            TargetChannelType::Peer
-        };
-
-        target_channels.insert(
-            channel.scid,
-            TargetChannel {
-                peer_pubkey: chan_policy.pubkey,
-                scid: channel.scid,
-                alias: chan_policy.alias.clone(),
-                channel_type,
-            },
-        );
-    }
-
-    target_channels
 }
 
 fn find_pubkey_by_alias(alias: &str, sim_network: &[NetworkParser]) -> Result<PublicKey, BoxError> {
@@ -412,78 +399,23 @@ fn find_pubkey_by_alias(alias: &str, sim_network: &[NetworkParser]) -> Result<Pu
     })
 }
 
-fn get_reputation_margin_fee(reputation_margin_msat: u64) -> u64 {
-    1000 + (0.0001 * reputation_margin_msat as f64) as u64
-}
-
-fn get_reputation_count(
-    reputation_margin_msat: u64,
-    reputation_margin_expiry_blocks: u32,
-    params: &ForwardManagerParams,
-    status: &NetworkReputation,
-) -> (usize, usize) {
-    let margin_fee = get_reputation_margin_fee(reputation_margin_msat);
-
-    let attacker_reputation =
-        status.reputation_count(false, params, margin_fee, reputation_margin_expiry_blocks);
-
-    let target_reputation =
-        status.reputation_count(true, params, margin_fee, reputation_margin_expiry_blocks);
-
-    (attacker_reputation, target_reputation)
-}
-
-/// Gets reputation pairs for the target node and attacking node, logs them and optionally checking that each node
-/// meets the configured threshold of good reputation if require_reputation is set.
-fn check_reputation_status(
-    cli: &Cli,
-    params: &ForwardManagerParams,
-    status: &NetworkReputation,
-    require_reputation: bool,
-) -> Result<(), BoxError> {
-    let (attacker_reputation, target_reputation) = get_reputation_count(
-        cli.reputation_margin_msat,
-        cli.reputation_margin_expiry_blocks,
-        params,
-        status,
-    );
-
-    log::info!(
-        "Attacker has {} out of {} pairs with reputation",
-        attacker_reputation,
-        status.attacker_reputation.len()
-    );
-
-    log::info!(
-        "Target has {}/{} pairs with reputation with its peers",
-        target_reputation,
-        status.target_reputation.len()
-    );
-
-    if !require_reputation {
-        return Ok(());
-    }
-
+/// Checks whether the attacker and target meet the required portion of high reputation pairs to required.
+fn check_reputation_status(cli: &Cli, status: &NetworkReputation) -> Result<(), BoxError> {
     let attacker_threshold =
-        status.attacker_reputation.len() * cli.attacker_reputation_percent as usize / 100;
-    if attacker_reputation < attacker_threshold {
+        status.attacker_pair_count * cli.attacker_reputation_percent as usize / 100;
+    if status.attacker_reputation < attacker_threshold {
         return Err(format!(
             "attacker has {}/{} good reputation pairs which does not meet threshold {}",
-            attacker_reputation,
-            status.attacker_reputation.len(),
-            attacker_threshold,
+            status.attacker_reputation, status.attacker_pair_count, attacker_threshold,
         )
         .into());
     }
 
-    let target_threshold =
-        status.target_reputation.len() * cli.target_reputation_percent as usize / 100;
-    if target_reputation < target_threshold {
+    let target_threshold = status.target_pair_count * cli.target_reputation_percent as usize / 100;
+    if status.target_reputation < target_threshold {
         return Err(format!(
             "target has {}/{} good reputation pairs which does not meet threshold {}",
-            target_reputation,
-            status.target_reputation.len(),
-            target_threshold,
+            status.target_reputation, status.target_pair_count, target_threshold,
         )
         .into());
     }
@@ -494,9 +426,6 @@ fn check_reputation_status(
 #[allow(clippy::too_many_arguments)]
 fn write_simulation_summary(
     data_dir: PathBuf,
-    reputation_margin_msat: u64,
-    reputation_margin_expiry_blocks: u32,
-    params: &ForwardManagerParams,
     revenue: &RevenueSnapshot,
     start_reputation: &NetworkReputation,
     end_reputation: &NetworkReputation,
@@ -535,42 +464,26 @@ fn write_simulation_summary(
         )?;
     }
 
-    let start_count = get_reputation_count(
-        reputation_margin_msat,
-        reputation_margin_expiry_blocks,
-        params,
-        start_reputation,
-    );
-    let end_count = get_reputation_count(
-        reputation_margin_msat,
-        reputation_margin_expiry_blocks,
-        params,
-        end_reputation,
-    );
     writeln!(
         writer,
         "Attacker start reputation (pairs): {}/{}",
-        start_count.0,
-        start_reputation.attacker_reputation.len()
+        start_reputation.attacker_reputation, start_reputation.attacker_pair_count,
     )?;
     writeln!(
         writer,
         "Attacker end reputation (pairs): {}/{}",
-        end_count.0,
-        end_reputation.attacker_reputation.len()
+        end_reputation.attacker_reputation, end_reputation.attacker_pair_count,
     )?;
 
     writeln!(
         writer,
         "Target start reputation (pairs): {}/{}",
-        start_count.1,
-        start_reputation.target_reputation.len()
+        start_reputation.target_reputation, start_reputation.target_pair_count,
     )?;
     writeln!(
         writer,
         "Target end reputation (pairs): {}/{}",
-        end_count.1,
-        end_reputation.target_reputation.len()
+        end_reputation.attacker_reputation, end_reputation.attacker_pair_count,
     )?;
     writeln!(
         writer,

--- a/ln-simln-jamming/src/main.rs
+++ b/ln-simln-jamming/src/main.rs
@@ -3,7 +3,7 @@ use clap::Parser;
 use ln_resource_mgr::forward_manager::ForwardManagerParams;
 use ln_resource_mgr::ReputationParams;
 use ln_simln_jamming::analysis::BatchForwardWriter;
-use ln_simln_jamming::attack_interceptor::{AttackInterceptor, TargetChannelType};
+use ln_simln_jamming::attack_interceptor::AttackInterceptor;
 use ln_simln_jamming::clock::InstantClock;
 use ln_simln_jamming::parsing::{get_history_for_bootstrap, history_from_file, Cli};
 use ln_simln_jamming::reputation_interceptor::ReputationInterceptor;
@@ -15,7 +15,7 @@ use simln_lib::clock::Clock;
 use simln_lib::clock::SimulationClock;
 use simln_lib::interceptors::LatencyIntercepor;
 use simln_lib::sim_node::{Interceptor, SimulatedChannel};
-use simln_lib::{NetworkParser, ShortChannelID, Simulation, SimulationCfg};
+use simln_lib::{NetworkParser, Simulation, SimulationCfg};
 use simple_logger::SimpleLogger;
 use std::collections::HashMap;
 use std::fs::{self, OpenOptions};
@@ -92,19 +92,7 @@ async fn main() -> Result<(), BoxError> {
     monitor_nodes.push((target_pubkey, cli.target_alias.to_string()));
 
     // Create a map of all the target's channels, and a vec of its non-attacking peers.
-    let target_channel_map: HashMap<ShortChannelID, TargetChannelType> = target_channels
-        .iter()
-        .map(|(scid, (pk, _))| {
-            (
-                ShortChannelID::from(*scid),
-                if *pk == attacker_pubkey {
-                    TargetChannelType::Attacker
-                } else {
-                    TargetChannelType::Peer
-                },
-            )
-        })
-        .collect();
+    let target_channel_map = target_channels.keys().cloned().collect();
 
     let jammed_peers: Vec<(u64, PublicKey)> = target_channels
         .iter()

--- a/ln-simln-jamming/src/main.rs
+++ b/ln-simln-jamming/src/main.rs
@@ -185,12 +185,7 @@ async fn main() -> Result<(), BoxError> {
         }
     });
 
-    let attack_interceptor = AttackInterceptor::new_for_network(
-        clock.clone(),
-        attacker_pubkey,
-        target_pubkey,
-        target_channel_map,
-        honest_peers,
+    let reputation_interceptor = Arc::new(Mutex::new(
         ReputationInterceptor::new_with_bootstrap(
             forward_params,
             &sim_network,
@@ -201,6 +196,14 @@ async fn main() -> Result<(), BoxError> {
             shutdown.clone(),
         )
         .await?,
+    ));
+    let attack_interceptor = AttackInterceptor::new_for_network(
+        clock.clone(),
+        attacker_pubkey,
+        target_pubkey,
+        target_channel_map,
+        honest_peers,
+        reputation_interceptor,
         listener.clone(),
         shutdown.clone(),
     );


### PR DESCRIPTION
In preparation for #36, do some renaming and refactoring.
* We call things `incoming_revenue` in a lot of places, which is confusing when we're actually tracking this bidirectinally.
* Rename sink-specific files/structs
* Move to a more generic `list_channels` vs `list_reputation_pairs`