### PR TITLE
implement incoming reputation

### DIFF
--- a/ln-resource-mgr/src/forward_manager.rs
+++ b/ln-resource-mgr/src/forward_manager.rs
@@ -363,7 +363,7 @@ impl ReputationManager for ForwardManager {
             .lock()
             .map_err(|e| ReputationError::ErrUnrecoverable(e.to_string()))?;
 
-        // Remove the hltc from our tracker, as well as the incoming and outgoing direction's current state.
+        // Remove the htlc from our tracker, as well as the incoming and outgoing direction's current state.
         let in_flight = inner_lock
             .htlcs
             .remove_htlc(outgoing_channel, incoming_ref)?;
@@ -375,7 +375,7 @@ impl ReputationManager for ForwardManager {
                 incoming_ref.channel_id,
             ))?
             .incoming_direction
-            .remove_incoming_htlc(&in_flight, resolved_instant);
+            .remove_incoming_htlc(&in_flight, resolution, resolved_instant)?;
 
         inner_lock
             .channels

--- a/ln-resource-mgr/src/incoming_channel.rs
+++ b/ln-resource-mgr/src/incoming_channel.rs
@@ -1,12 +1,19 @@
+use std::ops::Sub;
 use std::time::Instant;
 
+use crate::decaying_average::DecayingAverage;
 use crate::htlc_manager::InFlightHtlc;
-use crate::{ReputationParams, ResourceBucketType};
+use crate::{ForwardResolution, ReputationError, ReputationParams, ResourceBucketType};
 
-/// Tracks information about the usage of the channels when it is utilized as the outgoing direction in a htlc forward.
+/// Tracks information about the usage of the channels when it is utilized as the incoming direction in a htlc forward.
 #[derive(Debug)]
 pub(super) struct IncomingChannel {
     params: ReputationParams,
+
+    /// The reputation that the channel has accrued as the incoming link in htlc forwards. Tracked as a decaying
+    /// average over the reputation_window that the tracker is created with.
+    incoming_reputation: DecayingAverage,
+
     /// Tracks the last instant that the incoming channel misused use of congested resources, if any.
     last_congestion_misuse: Option<Instant>,
 }
@@ -15,6 +22,9 @@ impl IncomingChannel {
     pub(super) fn new(params: ReputationParams) -> Self {
         Self {
             params,
+            incoming_reputation: DecayingAverage::new(
+                params.revenue_window * params.reputation_multiplier.into(),
+            ),
             last_congestion_misuse: None,
         }
     }
@@ -29,13 +39,41 @@ impl IncomingChannel {
         }
     }
 
+    /// Returns the reputation that the channel has earned in the incoming direction over [`revenue_window *
+    /// reputation_multiplier`].
+    pub(super) fn incoming_reputation(
+        &mut self,
+        access_instant: Instant,
+    ) -> Result<i64, ReputationError> {
+        self.incoming_reputation.value_at_instant(access_instant)
+    }
+
     /// Resolves an in flight htlc, updating use of congestion resources to reflect misuse, if any.
-    pub(super) fn remove_incoming_htlc(&mut self, in_flight: &InFlightHtlc, resolved_ins: Instant) {
+    pub(super) fn remove_incoming_htlc(
+        &mut self,
+        in_flight: &InFlightHtlc,
+        resolution: ForwardResolution,
+        resolved_ins: Instant,
+    ) -> Result<(), ReputationError> {
         if in_flight.bucket == ResourceBucketType::Congestion
             && resolved_ins.duration_since(in_flight.added_instant) >= self.params.resolution_period
         {
             self.last_congestion_misuse = Some(resolved_ins)
         }
+
+        let settled = resolution == ForwardResolution::Settled;
+        let effective_fees = self.params.effective_fees(
+            in_flight.fee_msat,
+            resolved_ins.sub(in_flight.added_instant),
+            in_flight.incoming_endorsed,
+            settled,
+        )?;
+
+        // Update reputation to reflect its reputation impact.
+        self.incoming_reputation
+            .add_value(effective_fees, resolved_ins)?;
+
+        Ok(())
     }
 }
 
@@ -45,7 +83,28 @@ mod tests {
 
     use super::IncomingChannel;
     use crate::htlc_manager::InFlightHtlc;
-    use crate::{EndorsementSignal, ReputationParams, ResourceBucketType};
+    use crate::{EndorsementSignal, ForwardResolution, ReputationParams, ResourceBucketType};
+
+    fn get_test_params() -> ReputationParams {
+        ReputationParams {
+            revenue_window: Duration::from_secs(60 * 60 * 24), // 1 week
+            reputation_multiplier: 10,
+            resolution_period: Duration::from_secs(60),
+            expected_block_speed: Some(Duration::from_secs(60 * 10)),
+        }
+    }
+
+    fn get_test_htlc(endorsed: EndorsementSignal, fee_msat: u64) -> InFlightHtlc {
+        InFlightHtlc {
+            outgoing_channel_id: 1,
+            hold_blocks: 1000,
+            outgoing_amt_msat: 2000,
+            fee_msat,
+            added_instant: Instant::now(),
+            incoming_endorsed: endorsed,
+            bucket: ResourceBucketType::General,
+        }
+    }
 
     #[test]
     fn test_no_congestion_abuse() {
@@ -61,34 +120,40 @@ mod tests {
         assert!(incoming_channel.no_congestion_misuse(now));
 
         // Fast resolving HTLC does not trigger misuse.
-        incoming_channel.remove_incoming_htlc(
-            &InFlightHtlc {
-                outgoing_channel_id: 1,
-                fee_msat: 100,
-                hold_blocks: 40,
-                outgoing_amt_msat: 5000,
-                added_instant: now,
-                incoming_endorsed: EndorsementSignal::Endorsed,
-                bucket: ResourceBucketType::Congestion,
-            },
-            now.checked_add(params.resolution_period / 2).unwrap(),
-        );
+        incoming_channel
+            .remove_incoming_htlc(
+                &InFlightHtlc {
+                    outgoing_channel_id: 1,
+                    fee_msat: 100,
+                    hold_blocks: 40,
+                    outgoing_amt_msat: 5000,
+                    added_instant: now,
+                    incoming_endorsed: EndorsementSignal::Endorsed,
+                    bucket: ResourceBucketType::Congestion,
+                },
+                ForwardResolution::Settled,
+                now.checked_add(params.resolution_period / 2).unwrap(),
+            )
+            .unwrap();
         assert!(incoming_channel.no_congestion_misuse(now));
 
         // Slow resolving HTLC does trigger misuse.
         let last_misuse = now.checked_add(params.resolution_period * 2).unwrap();
-        incoming_channel.remove_incoming_htlc(
-            &InFlightHtlc {
-                outgoing_channel_id: 1,
-                fee_msat: 100,
-                hold_blocks: 40,
-                outgoing_amt_msat: 5000,
-                added_instant: now,
-                incoming_endorsed: EndorsementSignal::Endorsed,
-                bucket: ResourceBucketType::Congestion,
-            },
-            last_misuse,
-        );
+        incoming_channel
+            .remove_incoming_htlc(
+                &InFlightHtlc {
+                    outgoing_channel_id: 1,
+                    fee_msat: 100,
+                    hold_blocks: 40,
+                    outgoing_amt_msat: 5000,
+                    added_instant: now,
+                    incoming_endorsed: EndorsementSignal::Endorsed,
+                    bucket: ResourceBucketType::Congestion,
+                },
+                ForwardResolution::Settled,
+                last_misuse,
+            )
+            .unwrap();
         assert!(!incoming_channel.no_congestion_misuse(now));
 
         // Only recover once the cooldown period has fully passed.
@@ -97,5 +162,38 @@ mod tests {
 
         let fully_recovered = last_misuse.checked_add(params.revenue_window).unwrap();
         assert!(!incoming_channel.no_congestion_misuse(fully_recovered));
+    }
+
+    #[test]
+    fn test_remove_incoming_htlc() {
+        let mut test_incoming_channel = IncomingChannel::new(get_test_params());
+
+        let htlc_1 = get_test_htlc(EndorsementSignal::Endorsed, 1000);
+        test_incoming_channel
+            .remove_incoming_htlc(&htlc_1, ForwardResolution::Settled, htlc_1.added_instant)
+            .unwrap();
+
+        assert_eq!(
+            test_incoming_channel
+                .incoming_reputation(htlc_1.added_instant)
+                .unwrap(),
+            htlc_1.fee_msat as i64
+        );
+
+        let htlc_2 = get_test_htlc(EndorsementSignal::Endorsed, 5000);
+        test_incoming_channel
+            .remove_incoming_htlc(
+                &htlc_2.clone(),
+                ForwardResolution::Failed,
+                htlc_2.added_instant,
+            )
+            .unwrap();
+
+        assert_eq!(
+            test_incoming_channel
+                .incoming_reputation(htlc_1.added_instant)
+                .unwrap(),
+            htlc_1.fee_msat as i64,
+        );
     }
 }

--- a/ln-resource-mgr/src/lib.rs
+++ b/ln-resource-mgr/src/lib.rs
@@ -139,11 +139,11 @@ pub enum FailureReason {
     NoReputation,
 }
 
-/// A snapshot of the reputation and resources available for a forward.
+/// A snapshot of the incoming and outgoing reputation and resources available for a forward.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct AllocationCheck {
-    /// The reputation values used to compare the incoming channel's revenue to the outgoing channel's reputation for
-    /// the htlc proposed.
+    /// The reputation values used to check the incoming and outgoing reputation for the htlc
+    /// proposed.
     pub reputation_check: ReputationCheck,
     /// Indicates whether the incoming channel is eligible to consume congestion resources.
     pub congestion_eligible: bool,
@@ -190,7 +190,11 @@ impl AllocationCheck {
     ) -> Result<ResourceBucketType, FailureReason> {
         match incoming_endorsed {
             EndorsementSignal::Endorsed => {
-                if self.reputation_check.sufficient_reputation() {
+                if self
+                    .reputation_check
+                    .outgoing_reputation
+                    .sufficient_reputation()
+                {
                     Ok(ResourceBucketType::Protected)
                 } else {
                     // If the htlc was endorsed but the peer doesn't have reputation, we consider giving them a shot
@@ -260,27 +264,35 @@ impl AllocationCheck {
     }
 }
 
-/// A snapshot of a reputation check for a htlc forward.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct ReputationCheck {
-    pub outgoing_reputation: i64,
+    /// Values used to check incoming reputation for the channel pair.
+    pub incoming_reputation: ReputationValues,
+    /// Values used to check outgoing reputation for the channel pair.
+    pub outgoing_reputation: ReputationValues,
+}
+
+/// A snapshot of a reputation check for a htlc forward.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct ReputationValues {
+    pub reputation: i64,
     pub revenue_threshold: i64,
     pub in_flight_total_risk: u64,
     pub htlc_risk: u64,
 }
 
-impl ReputationCheck {
-    /// Returns a boolean indicating whether the outgoing channel has sufficient reputation for this htlc to be
-    /// forwarded to it.
+impl ReputationValues {
+    /// Returns a boolean indicating whether the channel has sufficient reputation for this htlc to be
+    /// forwarded.
     pub fn sufficient_reputation(&self) -> bool {
-        self.outgoing_reputation
+        self.reputation
             .saturating_sub(i64::try_from(self.in_flight_total_risk).unwrap_or(i64::MAX))
             .saturating_sub(i64::try_from(self.htlc_risk).unwrap_or(i64::MAX))
             > self.revenue_threshold
     }
 }
 
-/// A snapshot of the resource check for a htlc forward.
+/// A snapshot of the resource values to do a check on a htlc forward.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct ResourceCheck {
     pub general_bucket: BucketResources,
@@ -297,8 +309,8 @@ pub struct BucketResources {
 }
 
 impl BucketResources {
-    fn resources_available(&self, htlc_amt_mast: u64) -> bool {
-        if self.liquidity_used_msat + htlc_amt_mast > self.liquidity_available_msat {
+    fn resources_available(&self, htlc_amt_msat: u64) -> bool {
+        if self.liquidity_used_msat + htlc_amt_msat > self.liquidity_available_msat {
             return false;
         }
 
@@ -416,6 +428,7 @@ impl ProposedForward {
 /// Provides a snapshot of the reputation and revenue values tracked for a channel.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ChannelSnapshot {
+    pub incoming_reputation: i64,
     pub outgoing_reputation: i64,
     pub bidirectional_revenue: i64,
 }
@@ -490,17 +503,22 @@ pub trait ReputationManager {
 mod tests {
     use crate::{
         AllocationCheck, BucketResources, EndorsementSignal, FailureReason, ReputationCheck,
-        ResourceBucketType, ResourceCheck, MINIMUM_CONGESTION_SLOT_LIQUDITY,
+        ReputationValues, ResourceBucketType, ResourceCheck, MINIMUM_CONGESTION_SLOT_LIQUDITY,
     };
 
     /// Returns an AllocationCheck which is eligible for congestion resources.
     fn test_congestion_check() -> AllocationCheck {
+        let reputation_values = ReputationValues {
+            reputation: 0,
+            revenue_threshold: 0,
+            in_flight_total_risk: 0,
+            htlc_risk: 0,
+        };
+
         let check = AllocationCheck {
             reputation_check: ReputationCheck {
-                outgoing_reputation: 0,
-                revenue_threshold: 0,
-                in_flight_total_risk: 0,
-                htlc_risk: 0,
+                incoming_reputation: reputation_values.clone(),
+                outgoing_reputation: reputation_values,
             },
             congestion_eligible: true,
             resource_check: ResourceCheck {
@@ -596,7 +614,7 @@ mod tests {
     #[test]
     fn test_inner_forwarding_outcome_reputation() {
         let mut check = test_congestion_check();
-        check.reputation_check.outgoing_reputation = 1000;
+        check.reputation_check.outgoing_reputation.reputation = 1000;
         check.resource_check.general_bucket.slots_used = 0;
 
         // Sufficient reputation and endorsed will go in the protected bucket.

--- a/ln-simln-jamming/src/analysis.rs
+++ b/ln-simln-jamming/src/analysis.rs
@@ -57,17 +57,60 @@ impl Serialize for Record {
                 .forwarding_outcome(self.forward.amount_in_msat, self.forward.incoming_endorsed),
         )?;
         state.serialize_field(
-            "revenue_threshold",
-            &self.decision.reputation_check.revenue_threshold,
+            "rep_incoming_revenue_threshold",
+            &self
+                .decision
+                .reputation_check
+                .incoming_reputation
+                .revenue_threshold,
         )?;
         state.serialize_field(
-            "outgoing_reputation",
-            &self.decision.reputation_check.outgoing_reputation,
+            "rep_incoming_reputation",
+            &self
+                .decision
+                .reputation_check
+                .incoming_reputation
+                .reputation,
         )?;
-        state.serialize_field("htlc_risk", &self.decision.reputation_check.htlc_risk)?;
         state.serialize_field(
-            "in_flight_risk",
-            &self.decision.reputation_check.in_flight_total_risk,
+            "rep_incoming_htlc_risk",
+            &self.decision.reputation_check.incoming_reputation.htlc_risk,
+        )?;
+        state.serialize_field(
+            "rep_incoming_in_flight_risk",
+            &self
+                .decision
+                .reputation_check
+                .incoming_reputation
+                .in_flight_total_risk,
+        )?;
+        state.serialize_field(
+            "rep_outgoing_revenue_threshold",
+            &self
+                .decision
+                .reputation_check
+                .outgoing_reputation
+                .revenue_threshold,
+        )?;
+        state.serialize_field(
+            "rep_outgoing_reputation",
+            &self
+                .decision
+                .reputation_check
+                .outgoing_reputation
+                .reputation,
+        )?;
+        state.serialize_field(
+            "rep_outgoing_htlc_risk",
+            &self.decision.reputation_check.outgoing_reputation.htlc_risk,
+        )?;
+        state.serialize_field(
+            "rep_outgoing_in_flight_risk",
+            &self
+                .decision
+                .reputation_check
+                .outgoing_reputation
+                .in_flight_total_risk,
         )?;
         state.serialize_field(
             "slots_available",

--- a/ln-simln-jamming/src/lib.rs
+++ b/ln-simln-jamming/src/lib.rs
@@ -147,7 +147,7 @@ mod tests {
     use crate::{BoxError, NetworkReputation};
     use async_trait::async_trait;
     use bitcoin::secp256k1::PublicKey;
-    use ln_resource_mgr::{AllocationCheck, ChannelSnapshot, ReputationError};
+    use ln_resource_mgr::{ChannelSnapshot, ForwardingOutcome, ReputationError};
     use mockall::mock;
     use std::collections::HashMap;
     use std::sync::Arc;
@@ -160,7 +160,7 @@ mod tests {
         #[async_trait]
         impl ReputationMonitor for Monitor{
             async fn list_channels(&self, node: PublicKey, access_ins: Instant) -> Result<HashMap<u64, ChannelSnapshot>, BoxError>;
-            async fn check_htlc_outcome(&self,htlc_add: HtlcAdd) -> Result<AllocationCheck, ReputationError>;
+            async fn check_htlc_outcome(&self,htlc_add: HtlcAdd) -> Result<ForwardingOutcome, ReputationError>;
         }
     }
 
@@ -172,6 +172,9 @@ mod tests {
             (
                 0,
                 ChannelSnapshot {
+                    // TODO: count_reputation_pairs method does not use incoming reputation for the
+                    // outcome of the simulation yet. Hence, putting dummy values here.
+                    incoming_reputation: 100_000,
                     outgoing_reputation: 100_000,
                     bidirectional_revenue: 20_000,
                 },
@@ -179,6 +182,7 @@ mod tests {
             (
                 1,
                 ChannelSnapshot {
+                    incoming_reputation: 100_000,
                     outgoing_reputation: 45_000,
                     bidirectional_revenue: 50_000,
                 },
@@ -186,6 +190,7 @@ mod tests {
             (
                 2,
                 ChannelSnapshot {
+                    incoming_reputation: 100_000,
                     outgoing_reputation: 15_000,
                     bidirectional_revenue: 80_000,
                 },
@@ -235,6 +240,7 @@ mod tests {
                         (
                             0,
                             ChannelSnapshot {
+                                incoming_reputation: 100,
                                 outgoing_reputation: 100,
                                 bidirectional_revenue: 15,
                             },
@@ -242,6 +248,7 @@ mod tests {
                         (
                             1,
                             ChannelSnapshot {
+                                incoming_reputation: 100,
                                 outgoing_reputation: 150,
                                 bidirectional_revenue: 110,
                             },
@@ -249,6 +256,7 @@ mod tests {
                         (
                             2,
                             ChannelSnapshot {
+                                incoming_reputation: 100,
                                 outgoing_reputation: 200,
                                 bidirectional_revenue: 90,
                             },
@@ -256,6 +264,7 @@ mod tests {
                         (
                             3,
                             ChannelSnapshot {
+                                incoming_reputation: 100,
                                 outgoing_reputation: 75,
                                 bidirectional_revenue: 100,
                             },
@@ -266,6 +275,7 @@ mod tests {
                         (
                             1,
                             ChannelSnapshot {
+                                incoming_reputation: 100,
                                 outgoing_reputation: 500,
                                 bidirectional_revenue: 15,
                             },
@@ -273,6 +283,7 @@ mod tests {
                         (
                             4,
                             ChannelSnapshot {
+                                incoming_reputation: 100,
                                 outgoing_reputation: 150,
                                 bidirectional_revenue: 600,
                             },
@@ -280,6 +291,7 @@ mod tests {
                         (
                             5,
                             ChannelSnapshot {
+                                incoming_reputation: 100,
                                 outgoing_reputation: 200,
                                 bidirectional_revenue: 250,
                             },
@@ -290,6 +302,7 @@ mod tests {
                         (
                             2,
                             ChannelSnapshot {
+                                incoming_reputation: 100,
                                 outgoing_reputation: 1000,
                                 bidirectional_revenue: 50,
                             },
@@ -297,6 +310,7 @@ mod tests {
                         (
                             6,
                             ChannelSnapshot {
+                                incoming_reputation: 100,
                                 outgoing_reputation: 350,
                                 bidirectional_revenue: 800,
                             },
@@ -306,6 +320,7 @@ mod tests {
                     vec![(
                         3,
                         ChannelSnapshot {
+                            incoming_reputation: 100,
                             outgoing_reputation: 1000,
                             bidirectional_revenue: 50,
                         },

--- a/ln-simln-jamming/src/main.rs
+++ b/ln-simln-jamming/src/main.rs
@@ -196,19 +196,21 @@ async fn main() -> Result<(), BoxError> {
         }
     });
 
-    let reputation_interceptor = Arc::new(Mutex::new(
-        ReputationInterceptor::new_with_bootstrap(
-            forward_params,
-            &sim_network,
-            &jammed_peers,
-            &bootstrap,
-            reputation_check,
-            clock.clone(),
-            Some(results_writer),
-            shutdown.clone(),
-        )
-        .await?,
-    ));
+    let reputation_interceptor = Arc::new(Mutex::new(ReputationInterceptor::new_for_network(
+        forward_params,
+        &sim_network,
+        reputation_check,
+        clock.clone(),
+        Some(results_writer),
+        shutdown.clone(),
+    )?));
+
+    reputation_interceptor
+        .lock()
+        .await
+        .bootstrap_network(&bootstrap, &jammed_peers)
+        .await?;
+
     let attack_interceptor = AttackInterceptor::new_for_network(
         clock.clone(),
         attacker_pubkey,

--- a/ln-simln-jamming/src/parsing.rs
+++ b/ln-simln-jamming/src/parsing.rs
@@ -128,6 +128,14 @@ pub struct Cli {
     /// The alias of the attacking node.
     #[arg(long)]
     pub attacker_alias: String,
+
+    /// Only check incoming reputation for the simulation.
+    #[arg(long)]
+    pub incoming_reputation_only: bool,
+
+    /// Only check outgoing reputation for the simulation.
+    #[arg(long)]
+    pub outgoing_reputation_only: bool,
 }
 
 impl Cli {

--- a/ln-simln-jamming/src/test_utils.rs
+++ b/ln-simln-jamming/src/test_utils.rs
@@ -3,6 +3,7 @@ use std::time::Instant;
 
 use bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey};
 use lightning::ln::PaymentHash;
+use ln_resource_mgr::forward_manager::Reputation;
 use ln_resource_mgr::{
     AllocationCheck, BucketResources, EndorsementSignal, ForwardingOutcome, ProposedForward,
     ReputationCheck, ReputationValues, ResourceCheck,
@@ -98,7 +99,7 @@ pub fn test_allocation_check(forward_succeeds: bool) -> AllocationCheck {
 
     assert!(
         matches!(
-            check.forwarding_outcome(0, EndorsementSignal::Endorsed),
+            check.forwarding_outcome(0, EndorsementSignal::Endorsed, Reputation::Outgoing),
             ForwardingOutcome::Forward(_)
         ) == forward_succeeds
     );

--- a/ln-simln-jamming/src/test_utils.rs
+++ b/ln-simln-jamming/src/test_utils.rs
@@ -5,7 +5,7 @@ use bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey};
 use lightning::ln::PaymentHash;
 use ln_resource_mgr::{
     AllocationCheck, BucketResources, EndorsementSignal, ForwardingOutcome, ProposedForward,
-    ReputationCheck, ResourceCheck,
+    ReputationCheck, ReputationValues, ResourceCheck,
 };
 use rand::{distributions::Uniform, Rng};
 use simln_lib::sim_node::{CustomRecords, ForwardingError, InterceptRequest};
@@ -67,12 +67,17 @@ pub fn setup_test_request(
 
 #[allow(dead_code)]
 pub fn test_allocation_check(forward_succeeds: bool) -> AllocationCheck {
+    let reputation_values = ReputationValues {
+        reputation: 100_000,
+        revenue_threshold: if forward_succeeds { 0 } else { 200_000 },
+        in_flight_total_risk: 0,
+        htlc_risk: 0,
+    };
+
     let check = AllocationCheck {
         reputation_check: ReputationCheck {
-            outgoing_reputation: 100_000,
-            revenue_threshold: if forward_succeeds { 0 } else { 200_000 },
-            in_flight_total_risk: 0,
-            htlc_risk: 0,
+            incoming_reputation: reputation_values.clone(),
+            outgoing_reputation: reputation_values,
         },
         congestion_eligible: true,
         resource_check: ResourceCheck {


### PR DESCRIPTION
This PR adds incoming reputation. 

When assessing an htlc, The `ForwardManager` now returns an `AllocationCheck` that includes values to check both incoming and outgoing reputation. 

The option to do either incoming or outgoing or both can be passed to the reputation and forward manager and it will do the checks accordingly when deciding to add a new htlc.

