### PR TITLE
makefile: install reputation_builder in install-tools command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,5 +12,8 @@ stable-output:
 
 check: check-code stable-output
 
+install-tools:
+	cargo install --locked --path ln-simln-jamming --bin reputation-builder
+
 install:
 	cargo install --locked --path ln-simln-jamming

--- a/ln-simln-jamming/Cargo.toml
+++ b/ln-simln-jamming/Cargo.toml
@@ -3,7 +3,9 @@ name = "ln-simln-jamming"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[[bin]]
+name = "reputation-builder"
+path = "src/bin/reputation_builder.rs"
 
 [dependencies]
 simln-lib = { git = "https://github.com/carlaKC/sim-ln", rev = "e55133e" }


### PR DESCRIPTION
Add to makefile in a separate command. In future I can see us adding additional tooling binaries (such as one to generate the bootstrap data), so putting this under a generic title in preparation.