### PR TITLE
remove incoming reputation and rename accountability

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ will:
 - Open up channels and forward payments as usual to bootstrap its
   reputation with a target node.
 - Slow jam the target's peers's general resources, so that all HTLCs
-  must be endorsed to reach the target.
-- Hold any endorsed HTLCs from the target with the goal of ruining its
+  must be accountable to reach the target.
+- Hold any accountable HTLCs from the target with the goal of ruining its
   reputation with its peers.
 
 ## Requirements
@@ -53,7 +53,7 @@ channels in the network have been around for at least the
 `reputation_window`.
 
 The simulation will then start, implementing the attack as follows:
-- General jamming the target's peers, so that only endorsed HTLCs
+- General jamming the target's peers, so that only accountable HTLCs
   reach the target node.
 - The attacking node will hold HTLCs for the maximum allowable period
   before risking a force close, then fail them back.
@@ -76,7 +76,7 @@ The simulation will shut down if:
   our best guess at how payments flow in the network.
 - Payments are generated with a fixed seed, but this is not perfectly
   deterministic in sim-ln.
-- The simulator implements "just in time" endorsement, bumping up
-  the endorsement signal of a htlc only if it is required.
+- The simulator implements "just in time" upgradable accountability, bumping up
+  the accountability signal of a htlc only if it is required.
 - At present the simulator only expects one channel between the target
   and attacking node.

--- a/ln-resource-mgr/src/forward_manager.rs
+++ b/ln-resource-mgr/src/forward_manager.rs
@@ -344,8 +344,8 @@ impl ReputationManager for ForwardManager {
 
         if let Ok(bucket) = allocation_check.inner_forwarding_outcome(
             forward.amount_out_msat,
-            forward.incoming_endorsed,
-            forward.upgradable_endorsement,
+            forward.incoming_accountable,
+            forward.upgradable_accountability,
         ) {
             inner_lock.htlcs.add_htlc(
                 forward.incoming_ref,
@@ -355,7 +355,7 @@ impl ReputationManager for ForwardManager {
                     outgoing_amt_msat: forward.amount_out_msat,
                     fee_msat: forward.fee_msat(),
                     added_instant: forward.added_at,
-                    incoming_endorsed: forward.incoming_endorsed,
+                    accountable: forward.incoming_accountable,
                     bucket,
                 },
             )?;

--- a/ln-resource-mgr/src/forward_manager.rs
+++ b/ln-resource-mgr/src/forward_manager.rs
@@ -4,8 +4,8 @@ use crate::incoming_channel::IncomingChannel;
 use crate::outgoing_channel::{BucketParameters, OutgoingChannel};
 use crate::{
     AllocationCheck, BucketResources, ChannelSnapshot, ForwardResolution, HtlcRef, ProposedForward,
-    ReputationCheck, ReputationError, ReputationManager, ReputationParams, ReputationValues,
-    ResourceBucketType, ResourceCheck,
+    ReputationCheck, ReputationError, ReputationManager, ReputationParams, ResourceBucketType,
+    ResourceCheck,
 };
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
@@ -110,41 +110,8 @@ impl RevenueAverage {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum Reputation {
-    Incoming,
-    Outgoing,
-    Bidirectional,
-}
-
-impl Reputation {
-    pub fn sufficient_reputation(&self, check: &AllocationCheck) -> bool {
-        match self {
-            Reputation::Incoming => check
-                .reputation_check
-                .incoming_reputation
-                .sufficient_reputation(),
-            Reputation::Outgoing => check
-                .reputation_check
-                .outgoing_reputation
-                .sufficient_reputation(),
-            Reputation::Bidirectional => {
-                check
-                    .reputation_check
-                    .incoming_reputation
-                    .sufficient_reputation()
-                    && check
-                        .reputation_check
-                        .outgoing_reputation
-                        .sufficient_reputation()
-            }
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct ForwardManagerParams {
     pub reputation_params: ReputationParams,
-    pub reputation_check: Reputation,
     pub general_slot_portion: u8,
     pub general_liquidity_portion: u8,
     pub congestion_slot_portion: u8,
@@ -164,7 +131,7 @@ pub trait SimualtionDebugManager {
     fn general_jam_channel(&self, channel: u64) -> Result<(), ReputationError>;
 }
 
-/// Implements incoming and outgoing reputation algorithm and resource bucketing for an individual node.
+/// Implements outgoing reputation algorithm and resource bucketing for an individual node.
 #[derive(Debug)]
 pub struct ForwardManager {
     params: ForwardManagerParams,
@@ -195,55 +162,29 @@ impl ForwardManagerImpl {
             .bidirectional_revenue
             .value_at_instant(forward.added_at)?;
 
-        // Reputation from the incoming channel.
-        let incoming_reputation = incoming_channel
-            .incoming_direction
-            .incoming_reputation(forward.added_at)?;
-
         let no_congestion_misuse = incoming_channel
             .incoming_direction
             .no_congestion_misuse(forward.added_at);
 
         // Check reputation and resources available for the forward.
-        let outgoing_channel = self.channels.get_mut(&forward.outgoing_channel_id).ok_or(
-            ReputationError::ErrOutgoingNotFound(forward.outgoing_channel_id),
-        )?;
-
-        // Revenue over the outgoing channel that the incoming channel must meet.
-        let outgoing_revenue_threshold = outgoing_channel
-            .bidirectional_revenue
-            .value_at_instant(forward.added_at)?;
-
-        // Reputation from the outgoing channel
-        let outgoing_reputation = outgoing_channel
-            .outgoing_direction
-            .outgoing_reputation(forward.added_at)?;
+        let outgoing_channel = &mut self
+            .channels
+            .get_mut(&forward.outgoing_channel_id)
+            .ok_or(ReputationError::ErrOutgoingNotFound(
+                forward.outgoing_channel_id,
+            ))?
+            .outgoing_direction;
 
         Ok(AllocationCheck {
             reputation_check: ReputationCheck {
-                incoming_reputation: ReputationValues {
-                    reputation: incoming_reputation,
-                    revenue_threshold: outgoing_revenue_threshold,
-                    in_flight_total_risk: self.htlcs.channel_in_flight_risk(
-                        ChannelFilter::IncomingChannel(forward.incoming_ref.channel_id),
-                    ),
-                    // The underlying simulation is block height agnostic, and starts its routes with a height of zero, so
-                    // we can just use the expiry height to reflect "maximum time htlc can be held on channel", because
-                    // we're calculating expiry_in/out_height - 0.
-                    htlc_risk: self
-                        .htlcs
-                        .htlc_risk(forward.fee_msat(), forward.expiry_out_height),
-                },
-                outgoing_reputation: ReputationValues {
-                    reputation: outgoing_reputation,
-                    revenue_threshold: incoming_revenue_threshold,
-                    in_flight_total_risk: self.htlcs.channel_in_flight_risk(
-                        ChannelFilter::OutgoingChannel(forward.outgoing_channel_id),
-                    ),
-                    htlc_risk: self
-                        .htlcs
-                        .htlc_risk(forward.fee_msat(), forward.expiry_in_height),
-                },
+                reputation: outgoing_channel.outgoing_reputation(forward.added_at)?,
+                revenue_threshold: incoming_revenue_threshold,
+                in_flight_total_risk: self.htlcs.channel_in_flight_risk(
+                    ChannelFilter::OutgoingChannel(forward.outgoing_channel_id),
+                ),
+                htlc_risk: self
+                    .htlcs
+                    .htlc_risk(forward.fee_msat(), forward.expiry_in_height),
             },
             // The incoming channel can only use congestion resources if it hasn't recently misused congestion
             // resources and it doesn't currently have any htlcs using them.
@@ -257,36 +198,24 @@ impl ForwardManagerImpl {
                         forward.outgoing_channel_id,
                         ResourceBucketType::General,
                     ),
-                    slots_available: outgoing_channel
-                        .outgoing_direction
-                        .general_bucket
-                        .slot_count,
+                    slots_available: outgoing_channel.general_bucket.slot_count,
                     liquidity_used_msat: self.htlcs.bucket_in_flight_msat(
                         forward.outgoing_channel_id,
                         ResourceBucketType::General,
                     ),
-                    liquidity_available_msat: outgoing_channel
-                        .outgoing_direction
-                        .general_bucket
-                        .liquidity_msat,
+                    liquidity_available_msat: outgoing_channel.general_bucket.liquidity_msat,
                 },
                 congestion_bucket: BucketResources {
                     slots_used: self.htlcs.bucket_in_flight_count(
                         forward.outgoing_channel_id,
                         ResourceBucketType::Congestion,
                     ),
-                    slots_available: outgoing_channel
-                        .outgoing_direction
-                        .congestion_bucket
-                        .slot_count,
+                    slots_available: outgoing_channel.congestion_bucket.slot_count,
                     liquidity_used_msat: self.htlcs.bucket_in_flight_msat(
                         forward.outgoing_channel_id,
                         ResourceBucketType::Congestion,
                     ),
-                    liquidity_available_msat: outgoing_channel
-                        .outgoing_direction
-                        .congestion_bucket
-                        .liquidity_msat,
+                    liquidity_available_msat: outgoing_channel.congestion_bucket.liquidity_msat,
                 },
             },
         })
@@ -345,10 +274,6 @@ impl ReputationManager for ForwardManager {
                 let congestion_liquidity_amount =
                     capacity_msat * self.params.congestion_liquidity_portion as u64 / 100;
 
-                let incoming_reputation = channel_reputation
-                    .as_ref()
-                    .map(|channel| (channel.incoming_reputation, add_ins));
-
                 let outgoing_reputation = channel_reputation
                     .as_ref()
                     .map(|channel| (channel.outgoing_reputation, add_ins));
@@ -365,10 +290,7 @@ impl ReputationManager for ForwardManager {
 
                 v.insert(TrackedChannel {
                     capacity_msat,
-                    incoming_direction: IncomingChannel::new(
-                        self.params.reputation_params,
-                        incoming_reputation,
-                    )?,
+                    incoming_direction: IncomingChannel::new(self.params.reputation_params),
                     outgoing_direction: OutgoingChannel::new(
                         self.params.reputation_params,
                         BucketParameters {
@@ -424,7 +346,6 @@ impl ReputationManager for ForwardManager {
             forward.amount_out_msat,
             forward.incoming_endorsed,
             forward.upgradable_endorsement,
-            self.params.reputation_check,
         ) {
             inner_lock.htlcs.add_htlc(
                 forward.incoming_ref,
@@ -467,7 +388,7 @@ impl ReputationManager for ForwardManager {
                 incoming_ref.channel_id,
             ))?
             .incoming_direction
-            .remove_incoming_htlc(&in_flight, resolution, resolved_instant)?;
+            .remove_incoming_htlc(&in_flight, resolved_instant);
 
         inner_lock
             .channels
@@ -520,9 +441,6 @@ impl ReputationManager for ForwardManager {
                 *scid,
                 ChannelSnapshot {
                     capacity_msat: channel.capacity_msat,
-                    incoming_reputation: channel
-                        .incoming_direction
-                        .incoming_reputation(access_ins)?,
                     outgoing_reputation: channel
                         .outgoing_direction
                         .outgoing_reputation(access_ins)?,

--- a/ln-resource-mgr/src/incoming_channel.rs
+++ b/ln-resource-mgr/src/incoming_channel.rs
@@ -45,7 +45,7 @@ mod tests {
 
     use super::IncomingChannel;
     use crate::htlc_manager::InFlightHtlc;
-    use crate::{EndorsementSignal, ReputationParams, ResourceBucketType};
+    use crate::{AccountableSignal, ReputationParams, ResourceBucketType};
 
     #[test]
     fn test_no_congestion_abuse() {
@@ -68,7 +68,7 @@ mod tests {
                 hold_blocks: 40,
                 outgoing_amt_msat: 5000,
                 added_instant: now,
-                incoming_endorsed: EndorsementSignal::Endorsed,
+                accountable: AccountableSignal::Accountable,
                 bucket: ResourceBucketType::Congestion,
             },
             now.checked_add(params.resolution_period / 2).unwrap(),
@@ -84,7 +84,7 @@ mod tests {
                 hold_blocks: 40,
                 outgoing_amt_msat: 5000,
                 added_instant: now,
-                incoming_endorsed: EndorsementSignal::Endorsed,
+                accountable: AccountableSignal::Accountable,
                 bucket: ResourceBucketType::Congestion,
             },
             last_misuse,

--- a/ln-resource-mgr/src/incoming_channel.rs
+++ b/ln-resource-mgr/src/incoming_channel.rs
@@ -1,46 +1,22 @@
-use std::ops::Sub;
 use std::time::Instant;
 
-use crate::decaying_average::DecayingAverage;
 use crate::htlc_manager::InFlightHtlc;
-use crate::{ForwardResolution, ReputationError, ReputationParams, ResourceBucketType};
+use crate::{ReputationParams, ResourceBucketType};
 
 /// Tracks information about the usage of the channels when it is utilized as the incoming direction in a htlc forward.
 #[derive(Debug)]
 pub(super) struct IncomingChannel {
     params: ReputationParams,
-
-    /// The reputation that the channel has accrued as the incoming link in htlc forwards. Tracked as a decaying
-    /// average over the reputation_window that the tracker is created with.
-    incoming_reputation: DecayingAverage,
-
     /// Tracks the last instant that the incoming channel misused use of congested resources, if any.
     last_congestion_misuse: Option<Instant>,
 }
 
 impl IncomingChannel {
-    pub(super) fn new(
-        params: ReputationParams,
-        incoming_reputation: Option<(i64, Instant)>,
-    ) -> Result<Self, ReputationError> {
-        let incoming_reputation = match incoming_reputation {
-            Some(value) => {
-                let mut reputation = DecayingAverage::new(
-                    params.revenue_window * params.reputation_multiplier.into(),
-                );
-                reputation.add_value(value.0, value.1)?;
-                reputation
-            }
-            None => {
-                DecayingAverage::new(params.revenue_window * params.reputation_multiplier.into())
-            }
-        };
-
-        Ok(Self {
+    pub(super) fn new(params: ReputationParams) -> Self {
+        Self {
             params,
-            incoming_reputation,
             last_congestion_misuse: None,
-        })
+        }
     }
 
     /// Returns true if the channel has never misused congestion resources, or sufficient time has passed since last
@@ -53,41 +29,13 @@ impl IncomingChannel {
         }
     }
 
-    /// Returns the reputation that the channel has earned in the incoming direction over [`revenue_window *
-    /// reputation_multiplier`].
-    pub(super) fn incoming_reputation(
-        &mut self,
-        access_instant: Instant,
-    ) -> Result<i64, ReputationError> {
-        self.incoming_reputation.value_at_instant(access_instant)
-    }
-
     /// Resolves an in flight htlc, updating use of congestion resources to reflect misuse, if any.
-    pub(super) fn remove_incoming_htlc(
-        &mut self,
-        in_flight: &InFlightHtlc,
-        resolution: ForwardResolution,
-        resolved_ins: Instant,
-    ) -> Result<(), ReputationError> {
+    pub(super) fn remove_incoming_htlc(&mut self, in_flight: &InFlightHtlc, resolved_ins: Instant) {
         if in_flight.bucket == ResourceBucketType::Congestion
             && resolved_ins.duration_since(in_flight.added_instant) >= self.params.resolution_period
         {
             self.last_congestion_misuse = Some(resolved_ins)
         }
-
-        let settled = resolution == ForwardResolution::Settled;
-        let effective_fees = self.params.effective_fees(
-            in_flight.fee_msat,
-            resolved_ins.sub(in_flight.added_instant),
-            in_flight.incoming_endorsed,
-            settled,
-        )?;
-
-        // Update reputation to reflect its reputation impact.
-        self.incoming_reputation
-            .add_value(effective_fees, resolved_ins)?;
-
-        Ok(())
     }
 }
 
@@ -97,28 +45,7 @@ mod tests {
 
     use super::IncomingChannel;
     use crate::htlc_manager::InFlightHtlc;
-    use crate::{EndorsementSignal, ForwardResolution, ReputationParams, ResourceBucketType};
-
-    fn get_test_params() -> ReputationParams {
-        ReputationParams {
-            revenue_window: Duration::from_secs(60 * 60 * 24), // 1 week
-            reputation_multiplier: 10,
-            resolution_period: Duration::from_secs(60),
-            expected_block_speed: Some(Duration::from_secs(60 * 10)),
-        }
-    }
-
-    fn get_test_htlc(endorsed: EndorsementSignal, fee_msat: u64) -> InFlightHtlc {
-        InFlightHtlc {
-            outgoing_channel_id: 1,
-            hold_blocks: 1000,
-            outgoing_amt_msat: 2000,
-            fee_msat,
-            added_instant: Instant::now(),
-            incoming_endorsed: endorsed,
-            bucket: ResourceBucketType::General,
-        }
-    }
+    use crate::{EndorsementSignal, ReputationParams, ResourceBucketType};
 
     #[test]
     fn test_no_congestion_abuse() {
@@ -129,45 +56,39 @@ mod tests {
             resolution_period: Duration::from_secs(90),
             expected_block_speed: None,
         };
-        let mut incoming_channel = IncomingChannel::new(params, None).unwrap();
+        let mut incoming_channel = IncomingChannel::new(params);
 
         assert!(incoming_channel.no_congestion_misuse(now));
 
         // Fast resolving HTLC does not trigger misuse.
-        incoming_channel
-            .remove_incoming_htlc(
-                &InFlightHtlc {
-                    outgoing_channel_id: 1,
-                    fee_msat: 100,
-                    hold_blocks: 40,
-                    outgoing_amt_msat: 5000,
-                    added_instant: now,
-                    incoming_endorsed: EndorsementSignal::Endorsed,
-                    bucket: ResourceBucketType::Congestion,
-                },
-                ForwardResolution::Settled,
-                now.checked_add(params.resolution_period / 2).unwrap(),
-            )
-            .unwrap();
+        incoming_channel.remove_incoming_htlc(
+            &InFlightHtlc {
+                outgoing_channel_id: 1,
+                fee_msat: 100,
+                hold_blocks: 40,
+                outgoing_amt_msat: 5000,
+                added_instant: now,
+                incoming_endorsed: EndorsementSignal::Endorsed,
+                bucket: ResourceBucketType::Congestion,
+            },
+            now.checked_add(params.resolution_period / 2).unwrap(),
+        );
         assert!(incoming_channel.no_congestion_misuse(now));
 
         // Slow resolving HTLC does trigger misuse.
         let last_misuse = now.checked_add(params.resolution_period * 2).unwrap();
-        incoming_channel
-            .remove_incoming_htlc(
-                &InFlightHtlc {
-                    outgoing_channel_id: 1,
-                    fee_msat: 100,
-                    hold_blocks: 40,
-                    outgoing_amt_msat: 5000,
-                    added_instant: now,
-                    incoming_endorsed: EndorsementSignal::Endorsed,
-                    bucket: ResourceBucketType::Congestion,
-                },
-                ForwardResolution::Settled,
-                last_misuse,
-            )
-            .unwrap();
+        incoming_channel.remove_incoming_htlc(
+            &InFlightHtlc {
+                outgoing_channel_id: 1,
+                fee_msat: 100,
+                hold_blocks: 40,
+                outgoing_amt_msat: 5000,
+                added_instant: now,
+                incoming_endorsed: EndorsementSignal::Endorsed,
+                bucket: ResourceBucketType::Congestion,
+            },
+            last_misuse,
+        );
         assert!(!incoming_channel.no_congestion_misuse(now));
 
         // Only recover once the cooldown period has fully passed.
@@ -176,38 +97,5 @@ mod tests {
 
         let fully_recovered = last_misuse.checked_add(params.revenue_window).unwrap();
         assert!(!incoming_channel.no_congestion_misuse(fully_recovered));
-    }
-
-    #[test]
-    fn test_remove_incoming_htlc() {
-        let mut test_incoming_channel = IncomingChannel::new(get_test_params(), None).unwrap();
-
-        let htlc_1 = get_test_htlc(EndorsementSignal::Endorsed, 1000);
-        test_incoming_channel
-            .remove_incoming_htlc(&htlc_1, ForwardResolution::Settled, htlc_1.added_instant)
-            .unwrap();
-
-        assert_eq!(
-            test_incoming_channel
-                .incoming_reputation(htlc_1.added_instant)
-                .unwrap(),
-            htlc_1.fee_msat as i64
-        );
-
-        let htlc_2 = get_test_htlc(EndorsementSignal::Endorsed, 5000);
-        test_incoming_channel
-            .remove_incoming_htlc(
-                &htlc_2.clone(),
-                ForwardResolution::Failed,
-                htlc_2.added_instant,
-            )
-            .unwrap();
-
-        assert_eq!(
-            test_incoming_channel
-                .incoming_reputation(htlc_1.added_instant)
-                .unwrap(),
-            htlc_1.fee_msat as i64,
-        );
     }
 }

--- a/ln-simln-jamming/src/analysis.rs
+++ b/ln-simln-jamming/src/analysis.rs
@@ -49,12 +49,12 @@ impl Serialize for Record {
         state.serialize_field("amount_out_msat", &self.forward.amount_out_msat)?;
         state.serialize_field("expiry_in_height", &self.forward.expiry_in_height)?;
         state.serialize_field("expiry_out_height", &self.forward.expiry_out_height)?;
-        state.serialize_field("incoming_endorsed", &self.forward.incoming_endorsed)?;
+        state.serialize_field("incoming_accountable", &self.forward.incoming_accountable)?;
         state.serialize_field(
             "forwarding_outcome",
             &self.decision.forwarding_outcome(
                 self.forward.amount_in_msat,
-                self.forward.incoming_endorsed,
+                self.forward.incoming_accountable,
                 true,
             ),
         )?;

--- a/ln-simln-jamming/src/analysis.rs
+++ b/ln-simln-jamming/src/analysis.rs
@@ -1,7 +1,6 @@
 use crate::BoxError;
 use bitcoin::secp256k1::PublicKey;
 use csv::WriterBuilder;
-use ln_resource_mgr::forward_manager::Reputation;
 use ln_resource_mgr::{AllocationCheck, ProposedForward};
 use serde::ser::SerializeStruct;
 use serde::{Serialize, Serializer};
@@ -17,14 +16,12 @@ pub trait ForwardReporter: Send + Sync {
         forwarding_node: PublicKey,
         decision: AllocationCheck,
         forward: ProposedForward,
-        reputation: Reputation,
     ) -> Result<(), BoxError>;
 }
 
 struct Record {
     forward: ProposedForward,
     decision: AllocationCheck,
-    reputation: Reputation,
     // Tracked with the record so that serialization can express a relative timestamp since the simulation started.
     start_ins: Instant,
 }
@@ -59,64 +56,20 @@ impl Serialize for Record {
                 self.forward.amount_in_msat,
                 self.forward.incoming_endorsed,
                 true,
-                self.reputation,
             ),
         )?;
         state.serialize_field(
-            "rep_incoming_revenue_threshold",
-            &self
-                .decision
-                .reputation_check
-                .incoming_reputation
-                .revenue_threshold,
+            "revenue_threshold",
+            &self.decision.reputation_check.revenue_threshold,
         )?;
         state.serialize_field(
-            "rep_incoming_reputation",
-            &self
-                .decision
-                .reputation_check
-                .incoming_reputation
-                .reputation,
+            "outgoing_reputation",
+            &self.decision.reputation_check.reputation,
         )?;
+        state.serialize_field("htlc_risk", &self.decision.reputation_check.htlc_risk)?;
         state.serialize_field(
-            "rep_incoming_htlc_risk",
-            &self.decision.reputation_check.incoming_reputation.htlc_risk,
-        )?;
-        state.serialize_field(
-            "rep_incoming_in_flight_risk",
-            &self
-                .decision
-                .reputation_check
-                .incoming_reputation
-                .in_flight_total_risk,
-        )?;
-        state.serialize_field(
-            "rep_outgoing_revenue_threshold",
-            &self
-                .decision
-                .reputation_check
-                .outgoing_reputation
-                .revenue_threshold,
-        )?;
-        state.serialize_field(
-            "rep_outgoing_reputation",
-            &self
-                .decision
-                .reputation_check
-                .outgoing_reputation
-                .reputation,
-        )?;
-        state.serialize_field(
-            "rep_outgoing_htlc_risk",
-            &self.decision.reputation_check.outgoing_reputation.htlc_risk,
-        )?;
-        state.serialize_field(
-            "rep_outgoing_in_flight_risk",
-            &self
-                .decision
-                .reputation_check
-                .outgoing_reputation
-                .in_flight_total_risk,
+            "in_flight_risk",
+            &self.decision.reputation_check.in_flight_total_risk,
         )?;
         state.serialize_field(
             "slots_available",
@@ -211,13 +164,11 @@ impl ForwardReporter for BatchForwardWriter {
         forwarding_node: PublicKey,
         decision: AllocationCheck,
         forward: ProposedForward,
-        reputation: Reputation,
     ) -> Result<(), BoxError> {
         if let Some((records, _)) = self.nodes.get_mut(&forwarding_node) {
             records.push(Record {
                 decision,
                 forward,
-                reputation,
                 start_ins: self.start_ins,
             });
             self.record_count += 1;
@@ -233,8 +184,6 @@ mod tests {
     use std::path::{Path, PathBuf};
     use std::str::FromStr;
     use std::time::{Instant, SystemTime};
-
-    use ln_resource_mgr::forward_manager::Reputation;
 
     use crate::analysis::get_file;
     use crate::test_utils::{get_random_keypair, test_allocation_check, test_proposed_forward};
@@ -257,12 +206,7 @@ mod tests {
         // Tracked node reported.
         let tracked_forward = test_proposed_forward(0);
         writer
-            .report_forward(
-                node_0,
-                test_allocation_check(true),
-                tracked_forward.clone(),
-                Reputation::Bidirectional,
-            )
+            .report_forward(node_0, test_allocation_check(true), tracked_forward.clone())
             .unwrap();
         assert_eq!(writer.record_count, 1);
 
@@ -272,7 +216,6 @@ mod tests {
                 node_1,
                 test_allocation_check(true),
                 test_proposed_forward(1),
-                Reputation::Bidirectional,
             )
             .unwrap();
         assert_eq!(writer.record_count, 1);
@@ -307,7 +250,6 @@ mod tests {
                 node_0,
                 test_allocation_check(true),
                 test_proposed_forward(0),
-                Reputation::Bidirectional,
             )
             .unwrap();
         assert_eq!(writer.record_count, 1);
@@ -322,7 +264,6 @@ mod tests {
                 node_1,
                 test_allocation_check(true),
                 test_proposed_forward(1),
-                Reputation::Bidirectional,
             )
             .unwrap();
         writer.write().unwrap();
@@ -334,7 +275,6 @@ mod tests {
                 node_0,
                 test_allocation_check(true),
                 test_proposed_forward(2),
-                Reputation::Bidirectional,
             )
             .unwrap();
         assert_eq!(writer.record_count, 2);
@@ -348,7 +288,6 @@ mod tests {
                 node_0,
                 test_allocation_check(true),
                 test_proposed_forward(3),
-                Reputation::Bidirectional,
             )
             .unwrap();
         writer
@@ -356,7 +295,6 @@ mod tests {
                 node_0,
                 test_allocation_check(true),
                 test_proposed_forward(4),
-                Reputation::Bidirectional,
             )
             .unwrap();
         writer
@@ -364,7 +302,6 @@ mod tests {
                 node_0,
                 test_allocation_check(true),
                 test_proposed_forward(5),
-                Reputation::Bidirectional,
             )
             .unwrap();
 

--- a/ln-simln-jamming/src/attacks/mod.rs
+++ b/ln-simln-jamming/src/attacks/mod.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use bitcoin::secp256k1::PublicKey;
 use simln_lib::sim_node::InterceptRequest;
 
-use crate::{endorsement_from_records, records_from_endorsement, BoxError, NetworkReputation};
+use crate::{accountable_from_records, records_from_signal, BoxError, NetworkReputation};
 
 pub mod sink;
 
@@ -35,11 +35,11 @@ pub trait JammingAttack {
     /// actions on HTLCs. This function may block, as it is spawned in a task, but *must* eventually send a response to
     /// the request.
     ///
-    /// The default implementation will forward HTLCs immediately, copying whatever incoming endorsement signal it
+    /// The default implementation will forward HTLCs immediately, copying whatever incoming accountable signal it
     /// received.
     async fn intercept_attacker_htlc(&self, req: InterceptRequest) -> Result<(), BoxError> {
         req.response
-            .send(Ok(Ok(records_from_endorsement(endorsement_from_records(
+            .send(Ok(Ok(records_from_signal(accountable_from_records(
                 &req.incoming_custom_records,
             )))))
             .await

--- a/ln-simln-jamming/src/lib.rs
+++ b/ln-simln-jamming/src/lib.rs
@@ -1,5 +1,5 @@
 use bitcoin::secp256k1::PublicKey;
-use ln_resource_mgr::{ChannelSnapshot, EndorsementSignal};
+use ln_resource_mgr::{AccountableSignal, ChannelSnapshot};
 use simln_lib::sim_node::{CustomRecords, InterceptRequest};
 use std::collections::HashMap;
 use std::error::Error;
@@ -21,28 +21,28 @@ pub(crate) mod test_utils;
 /// Error type for errors that can be erased, includes 'static so that down-casting is possible.
 pub type BoxError = Box<dyn Error + Send + Sync + 'static>;
 
-/// The TLV type used to represent experimental endorsement signals.
-pub const ENDORSEMENT_TYPE: u64 = 106823;
+/// The TLV type used to represent experimental accountable signals.
+pub const ACCOUNTABLE_TYPE: u64 = 106823;
 
-/// The TLV type used to represent upgradable endorsement signals. In real life this will be in
+/// The TLV type used to represent upgradable accountability signal. In real life this will be in
 /// the onion.
 pub const UPGRADABLE_TYPE: u64 = 106825;
 
-/// Converts a set of custom tlv records to an endorsement signal.
-pub fn endorsement_from_records(records: &CustomRecords) -> EndorsementSignal {
-    match records.get(&ENDORSEMENT_TYPE) {
-        Some(endorsed) => {
-            if endorsed.len() == 1 && endorsed[0] == 1 {
-                EndorsementSignal::Endorsed
+/// Converts a set of custom tlv records to an accountable signal.
+pub fn accountable_from_records(records: &CustomRecords) -> AccountableSignal {
+    match records.get(&ACCOUNTABLE_TYPE) {
+        Some(accountable) => {
+            if accountable.len() == 1 && accountable[0] == 1 {
+                AccountableSignal::Accountable
             } else {
-                EndorsementSignal::Unendorsed
+                AccountableSignal::Unaccountable
             }
         }
-        None => EndorsementSignal::Unendorsed,
+        None => AccountableSignal::Unaccountable,
     }
 }
 
-/// Converts a set of custom tlv records to a bool signaling if the endorsement signal is
+/// Converts a set of custom tlv records to a bool signaling if the accountable signal is
 /// upgradable.
 pub fn upgradable_from_records(records: &CustomRecords) -> bool {
     match records.get(&UPGRADABLE_TYPE) {
@@ -51,15 +51,15 @@ pub fn upgradable_from_records(records: &CustomRecords) -> bool {
     }
 }
 
-/// Converts an endorsement signal to custom records using the blip-04 experimental TLV. Note that
-/// we add by default the upgradable endorsement signal to the custom records returned.
-pub fn records_from_endorsement(endorsement: EndorsementSignal) -> CustomRecords {
+/// Converts an accountable signal to custom records using the blip-04 experimental TLV. Note that
+/// we add by default the upgradable accountability signal to the custom records returned.
+pub fn records_from_signal(signal: AccountableSignal) -> CustomRecords {
     let mut records = CustomRecords::default();
     records.insert(UPGRADABLE_TYPE, vec![1]);
-    match endorsement {
-        EndorsementSignal::Unendorsed => records,
-        EndorsementSignal::Endorsed => {
-            records.insert(ENDORSEMENT_TYPE, vec![1]);
+    match signal {
+        AccountableSignal::Unaccountable => records,
+        AccountableSignal::Accountable => {
+            records.insert(ACCOUNTABLE_TYPE, vec![1]);
             records
         }
     }
@@ -172,7 +172,7 @@ fn print_request(req: &InterceptRequest) -> String {
         "{}:{} {} -> {} with fee {} ({} -> {}) and cltv {} ({} -> {})",
         u64::from(req.incoming_htlc.channel_id),
         req.incoming_htlc.index,
-        endorsement_from_records(&req.incoming_custom_records),
+        accountable_from_records(&req.incoming_custom_records),
         if let Some(outgoing_chan) = req.outgoing_channel_id {
             outgoing_chan.into()
         } else {

--- a/ln-simln-jamming/src/lib.rs
+++ b/ln-simln-jamming/src/lib.rs
@@ -221,9 +221,6 @@ mod tests {
                 0,
                 ChannelSnapshot {
                     capacity_msat: 200_000,
-                    // TODO: count_reputation_pairs method does not use incoming reputation for the
-                    // outcome of the simulation yet. Hence, putting dummy values here.
-                    incoming_reputation: 100_000,
                     outgoing_reputation: 100_000,
                     bidirectional_revenue: 20_000,
                 },
@@ -232,7 +229,6 @@ mod tests {
                 1,
                 ChannelSnapshot {
                     capacity_msat: 200_000,
-                    incoming_reputation: 100_000,
                     outgoing_reputation: 45_000,
                     bidirectional_revenue: 50_000,
                 },
@@ -241,7 +237,6 @@ mod tests {
                 2,
                 ChannelSnapshot {
                     capacity_msat: 200_000,
-                    incoming_reputation: 100_000,
                     outgoing_reputation: 15_000,
                     bidirectional_revenue: 80_000,
                 },
@@ -292,7 +287,6 @@ mod tests {
                             0,
                             ChannelSnapshot {
                                 capacity_msat: 200_000,
-                                incoming_reputation: 100,
                                 outgoing_reputation: 100,
                                 bidirectional_revenue: 15,
                             },
@@ -301,7 +295,6 @@ mod tests {
                             1,
                             ChannelSnapshot {
                                 capacity_msat: 200_000,
-                                incoming_reputation: 100,
                                 outgoing_reputation: 150,
                                 bidirectional_revenue: 110,
                             },
@@ -310,7 +303,6 @@ mod tests {
                             2,
                             ChannelSnapshot {
                                 capacity_msat: 200_000,
-                                incoming_reputation: 100,
                                 outgoing_reputation: 200,
                                 bidirectional_revenue: 90,
                             },
@@ -319,7 +311,6 @@ mod tests {
                             3,
                             ChannelSnapshot {
                                 capacity_msat: 200_000,
-                                incoming_reputation: 100,
                                 outgoing_reputation: 75,
                                 bidirectional_revenue: 100,
                             },
@@ -331,7 +322,6 @@ mod tests {
                             1,
                             ChannelSnapshot {
                                 capacity_msat: 200_000,
-                                incoming_reputation: 100,
                                 outgoing_reputation: 500,
                                 bidirectional_revenue: 15,
                             },
@@ -340,7 +330,6 @@ mod tests {
                             4,
                             ChannelSnapshot {
                                 capacity_msat: 200_000,
-                                incoming_reputation: 100,
                                 outgoing_reputation: 150,
                                 bidirectional_revenue: 600,
                             },
@@ -349,7 +338,6 @@ mod tests {
                             5,
                             ChannelSnapshot {
                                 capacity_msat: 200_000,
-                                incoming_reputation: 100,
                                 outgoing_reputation: 200,
                                 bidirectional_revenue: 250,
                             },
@@ -361,7 +349,6 @@ mod tests {
                             2,
                             ChannelSnapshot {
                                 capacity_msat: 200_000,
-                                incoming_reputation: 100,
                                 outgoing_reputation: 1000,
                                 bidirectional_revenue: 50,
                             },
@@ -370,7 +357,6 @@ mod tests {
                             6,
                             ChannelSnapshot {
                                 capacity_msat: 200_000,
-                                incoming_reputation: 100,
                                 outgoing_reputation: 350,
                                 bidirectional_revenue: 800,
                             },
@@ -381,7 +367,6 @@ mod tests {
                         3,
                         ChannelSnapshot {
                             capacity_msat: 200_000,
-                            incoming_reputation: 100,
                             outgoing_reputation: 1000,
                             bidirectional_revenue: 50,
                         },

--- a/ln-simln-jamming/src/main.rs
+++ b/ln-simln-jamming/src/main.rs
@@ -14,7 +14,7 @@ use ln_simln_jamming::parsing::{
 use ln_simln_jamming::reputation_interceptor::ReputationInterceptor;
 use ln_simln_jamming::revenue_interceptor::{RevenueInterceptor, RevenueSnapshot};
 use ln_simln_jamming::{
-    get_network_reputation, BoxError, NetworkReputation, ENDORSEMENT_TYPE, UPGRADABLE_TYPE,
+    get_network_reputation, BoxError, NetworkReputation, ACCOUNTABLE_TYPE, UPGRADABLE_TYPE,
 };
 use log::LevelFilter;
 use simln_lib::clock::Clock;
@@ -273,7 +273,7 @@ async fn main() -> Result<(), BoxError> {
         .collect::<Vec<SimulatedChannel>>();
 
     let custom_records =
-        CustomRecords::from([(UPGRADABLE_TYPE, vec![1]), (ENDORSEMENT_TYPE, vec![0])]);
+        CustomRecords::from([(UPGRADABLE_TYPE, vec![1]), (ACCOUNTABLE_TYPE, vec![0])]);
 
     // Setup the simulated network with our fake graph.
     let (simulation, graph) = Simulation::new_with_sim_network(

--- a/ln-simln-jamming/src/main.rs
+++ b/ln-simln-jamming/src/main.rs
@@ -1,6 +1,6 @@
 use bitcoin::secp256k1::PublicKey;
 use clap::Parser;
-use ln_resource_mgr::forward_manager::{ForwardManagerParams, Reputation};
+use ln_resource_mgr::forward_manager::ForwardManagerParams;
 use ln_resource_mgr::ReputationParams;
 use ln_simln_jamming::analysis::BatchForwardWriter;
 use ln_simln_jamming::attack_interceptor::AttackInterceptor;
@@ -80,14 +80,6 @@ async fn main() -> Result<(), BoxError> {
 
     let clock = Arc::new(SimulationClock::new(cli.clock_speedup)?);
 
-    let reputation_check = if cli.incoming_reputation_only {
-        Reputation::Incoming
-    } else if cli.outgoing_reputation_only {
-        Reputation::Outgoing
-    } else {
-        Reputation::Bidirectional
-    };
-
     // Use the channel jamming interceptor and latency for simulated payments.
     let latency_interceptor: Arc<dyn Interceptor> =
         Arc::new(LatencyIntercepor::new_poisson(150.0)?);
@@ -100,7 +92,6 @@ async fn main() -> Result<(), BoxError> {
             resolution_period: Duration::from_secs(90),
             expected_block_speed: Some(Duration::from_secs(10 * 60)),
         },
-        reputation_check,
         general_slot_portion: 30,
         general_liquidity_portion: 30,
         congestion_slot_portion: 20,
@@ -147,7 +138,6 @@ async fn main() -> Result<(), BoxError> {
         ReputationInterceptor::new_from_snapshot(
             forward_params,
             &sim_network,
-            reputation_check,
             reputation_snapshot,
             clock.clone(),
             Some(results_writer),

--- a/ln-simln-jamming/src/parsing.rs
+++ b/ln-simln-jamming/src/parsing.rs
@@ -46,7 +46,7 @@ pub const DEFAULT_ATTACKER_REP_PERCENT: &str = "50";
 /// Default clock speedup to run with regular wall time.
 pub const DEFAULT_CLOCK_SPEEDUP: &str = "1";
 
-/// Default htlc size that a peer must be able to get endorsed to be considered as having good reputation, $10 at the
+/// Default htlc size that a peer must be able to get accountable to be considered as having good reputation, $10 at the
 /// time of writing.
 pub const DEFAULT_REPUTATION_MARGIN_MSAT: &str = "10000000";
 
@@ -104,7 +104,7 @@ pub struct Cli {
     #[arg(long, default_value = DEFAULT_CLOCK_SPEEDUP)]
     pub clock_speedup: u32,
 
-    /// The htlc amount that a peer must be able to get endorsed to be considered as having a good reputation, expressed
+    /// The htlc amount that a peer must be able to get accountable to be considered as having a good reputation, expressed
     /// in msat. This will be converted to a fee using a base fee of 1000 msat and a proportional charge of 0.01% of the
     /// amount.
     #[arg(long, default_value = DEFAULT_REPUTATION_MARGIN_MSAT)]

--- a/ln-simln-jamming/src/parsing.rs
+++ b/ln-simln-jamming/src/parsing.rs
@@ -142,14 +142,6 @@ pub struct Cli {
     /// The alias of the attacking node.
     #[arg(long)]
     pub attacker_alias: String,
-
-    /// Only check incoming reputation for the simulation.
-    #[arg(long)]
-    pub incoming_reputation_only: bool,
-
-    /// Only check outgoing reputation for the simulation.
-    #[arg(long)]
-    pub outgoing_reputation_only: bool,
 }
 
 impl Cli {
@@ -369,15 +361,13 @@ pub fn reputation_snapshot_from_file(
         let pubkey = PublicKey::from_slice(&hex::decode(&record[0])?)?;
         let scid: u64 = record[1].parse()?;
         let capacity_msat: u64 = record[2].parse()?;
-        let incoming_reputation: i64 = record[3].parse()?;
-        let outgoing_reputation: i64 = record[4].parse()?;
-        let bidirectional_revenue: i64 = record[5].parse()?;
+        let outgoing_reputation: i64 = record[3].parse()?;
+        let bidirectional_revenue: i64 = record[4].parse()?;
 
         reputation_snapshot.entry(pubkey).or_default().insert(
             scid,
             ChannelSnapshot {
                 capacity_msat,
-                incoming_reputation,
                 outgoing_reputation,
                 bidirectional_revenue,
             },

--- a/ln-simln-jamming/src/test_utils.rs
+++ b/ln-simln-jamming/src/test_utils.rs
@@ -7,10 +7,9 @@ use crate::{records_from_endorsement, BoxError};
 use async_trait::async_trait;
 use bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey};
 use lightning::ln::PaymentHash;
-use ln_resource_mgr::forward_manager::Reputation;
 use ln_resource_mgr::{
     AllocationCheck, BucketResources, ChannelSnapshot, EndorsementSignal, ForwardingOutcome,
-    ProposedForward, ReputationCheck, ReputationError, ReputationValues, ResourceCheck,
+    ProposedForward, ReputationCheck, ReputationError, ResourceCheck,
 };
 use mockall::mock;
 use rand::{distributions::Uniform, Rng};
@@ -88,17 +87,12 @@ pub fn setup_test_request(
 }
 
 pub fn test_allocation_check(forward_succeeds: bool) -> AllocationCheck {
-    let reputation_values = ReputationValues {
-        reputation: 100_000,
-        revenue_threshold: if forward_succeeds { 0 } else { 200_000 },
-        in_flight_total_risk: 0,
-        htlc_risk: 0,
-    };
-
     let check = AllocationCheck {
         reputation_check: ReputationCheck {
-            incoming_reputation: reputation_values.clone(),
-            outgoing_reputation: reputation_values,
+            reputation: 100_000,
+            revenue_threshold: if forward_succeeds { 0 } else { 200_000 },
+            in_flight_total_risk: 0,
+            htlc_risk: 0,
         },
         congestion_eligible: true,
         resource_check: ResourceCheck {
@@ -119,7 +113,7 @@ pub fn test_allocation_check(forward_succeeds: bool) -> AllocationCheck {
 
     assert!(
         matches!(
-            check.forwarding_outcome(0, EndorsementSignal::Endorsed, true, Reputation::Outgoing),
+            check.forwarding_outcome(0, EndorsementSignal::Endorsed, true),
             ForwardingOutcome::Forward(_)
         ) == forward_succeeds
     );


### PR DESCRIPTION
prefactor for https://github.com/carlaKC/jam-ln/issues/56

diff is a bit big but changes are:
- remove incoming reputation: Left as how it was before incoming reputation was added.
- renamed 1:1 from endorsement to accountability. As is, it does not match the proposal. As I was going through the code, added notes here: https://github.com/carlaKC/jam-ln/issues/56#issuecomment-2891424489 of things I think should change. Will continue updating that if I find anything else. 