### PR TITLE
Congestion accountable and bucket assigments

### DIFF
--- a/ln-resource-mgr/src/lib.rs
+++ b/ln-resource-mgr/src/lib.rs
@@ -183,7 +183,7 @@ impl AllocationCheck {
                     ForwardingOutcome::Forward(AccountableSignal::Unaccountable)
                 }
                 ResourceBucketType::Congestion => {
-                    ForwardingOutcome::Forward(AccountableSignal::Unaccountable)
+                    ForwardingOutcome::Forward(AccountableSignal::Accountable)
                 }
                 ResourceBucketType::Protected => {
                     ForwardingOutcome::Forward(AccountableSignal::Accountable)

--- a/ln-simln-jamming/src/bin/reputation_builder.rs
+++ b/ln-simln-jamming/src/bin/reputation_builder.rs
@@ -22,7 +22,7 @@ use ln_simln_jamming::{
         DEFAULT_REPUTATION_MULTIPLIER, DEFAULT_REVENUE_FILENAME, DEFAULT_REVENUE_WINDOW_SECONDS,
         DEFAULT_SIM_FILE,
     },
-    reputation_interceptor::{BoostrapRecords, ReputationInterceptor, ReputationMonitor},
+    reputation_interceptor::{BootstrapRecords, ReputationInterceptor, ReputationMonitor},
     BoxError,
 };
 use log::LevelFilter;
@@ -120,7 +120,7 @@ async fn main() -> Result<(), BoxError> {
             .max_by(|x, y| x.settled_ns.cmp(&y.settled_ns))
             .ok_or("at least one entry required in bootstrap history")?
             .settled_ns;
-        BoostrapRecords {
+        BootstrapRecords {
             forwards: unfiltered_history,
             last_timestamp_nanos,
         }

--- a/ln-simln-jamming/src/parsing.rs
+++ b/ln-simln-jamming/src/parsing.rs
@@ -1,4 +1,4 @@
-use crate::reputation_interceptor::{BoostrapRecords, BootstrapForward};
+use crate::reputation_interceptor::{BootstrapForward, BootstrapRecords};
 use crate::revenue_interceptor::RevenueEvent;
 use crate::BoxError;
 use bitcoin::secp256k1::PublicKey;
@@ -446,7 +446,7 @@ pub fn get_history_for_bootstrap(
     attacker_bootstrap: Duration,
     unfiltered_history: Vec<BootstrapForward>,
     attacker_channels: HashSet<u64>,
-) -> Result<BoostrapRecords, BoxError> {
+) -> Result<BootstrapRecords, BoxError> {
     let last_timestamp_nanos = unfiltered_history
         .iter()
         .max_by(|x, y| x.settled_ns.cmp(&y.settled_ns))
@@ -462,7 +462,7 @@ pub fn get_history_for_bootstrap(
     }
     let bootstrap_cutoff = last_timestamp_nanos - attacker_bootstrap.as_nanos() as u64;
 
-    Ok(BoostrapRecords {
+    Ok(BootstrapRecords {
         forwards: unfiltered_history
             .into_iter()
             .filter(|forward| {

--- a/ln-simln-jamming/src/reputation_interceptor.rs
+++ b/ln-simln-jamming/src/reputation_interceptor.rs
@@ -40,7 +40,7 @@ enum BootstrapEvent {
     BootstrapResolve(HtlcResolve),
 }
 
-pub struct BoostrapRecords {
+pub struct BootstrapRecords {
     pub forwards: Vec<BootstrapForward>,
     pub last_timestamp_nanos: u64,
 }
@@ -270,7 +270,7 @@ where
     /// Bootstraps the reputation of nodes in the interceptor network using the historical forwards provided.
     pub async fn bootstrap_network_history(
         &mut self,
-        bootstrap: &BoostrapRecords,
+        bootstrap: &BootstrapRecords,
     ) -> Result<(), BoxError> {
         // We'll get all instants relative to the last timestamp we're given, so we get an instant now and track
         // the last timestamp in the set of forwards.
@@ -621,7 +621,7 @@ mod tests {
 
     use crate::analysis::BatchForwardWriter;
     use crate::clock::InstantClock;
-    use crate::reputation_interceptor::{BoostrapRecords, BootstrapForward};
+    use crate::reputation_interceptor::{BootstrapForward, BootstrapRecords};
     use crate::test_utils::{get_random_keypair, setup_test_request, test_allocation_check};
     use crate::{accountable_from_records, BoxError};
 
@@ -1052,7 +1052,7 @@ mod tests {
             .unwrap();
 
         interceptor
-            .bootstrap_network_history(&BoostrapRecords {
+            .bootstrap_network_history(&BootstrapRecords {
                 forwards: bootstrap,
                 last_timestamp_nanos: 1_000_000,
             })


### PR DESCRIPTION
for https://github.com/carlaKC/jam-ln/issues/53, forward htlcs in congested bucket as `Accountable`.
And do bucket assignments in `inner_forwarding_outcome` as specified in latest proposal. 

Returning bucket assignment with this logic:
- if htlc is `unaccountable`:
    - if general resources available, assign to general bucket.
    - if congestion eligible and congestion resources available, assign to congestion bucket.
    - if no general or congestion resources available:
           - if peer has reputation, assign to protected bucket.
           - if no reputation, fail with no resources.
- if htlc is `accountable` 
       - check if peer has reputation and if so, assign to protected bucket. If no protected resources available, check general and then congestion. 
       - if no reputation, fail with no reputation error. 

Modified the tests to match this. 

Still TODOs in follow-up PRs:
- accountable signals returned from `forwarding_outcome` should match proposal. I don't think it fully does this yet. 
- Tests for `forwarding_outcome`.
- I think we'll need to merge `forwarding_outcome` and `inner_forwarding_outcome` on the `AllocationCheck` since we'll need both the accountable signal and bucket together when adding a new htlc. 
- <s>track protected resources<s>. 