### PR TITLE
ln-simln-jamming: move logging out of check_reputation_status

### DIFF
--- a/ln-simln-jamming/src/lib.rs
+++ b/ln-simln-jamming/src/lib.rs
@@ -120,18 +120,6 @@ pub async fn get_network_reputation<R: ReputationMonitor>(
         }
     }
 
-    log::info!(
-        "Attacker has {} out of {} pairs with reputation",
-        network_reputation.attacker_reputation,
-        network_reputation.attacker_pair_count,
-    );
-
-    log::info!(
-        "Target has {}/{} pairs with reputation with its peers",
-        network_reputation.target_reputation,
-        network_reputation.target_pair_count,
-    );
-
     Ok(network_reputation)
 }
 

--- a/ln-simln-jamming/src/main.rs
+++ b/ln-simln-jamming/src/main.rs
@@ -317,6 +317,18 @@ async fn main() -> Result<(), BoxError> {
 
 /// Checks whether the attacker and target meet the required portion of high reputation pairs to required.
 fn check_reputation_status(cli: &Cli, status: &NetworkReputation) -> Result<(), BoxError> {
+    log::info!(
+        "Attacker has {} out of {} pairs with reputation",
+        status.attacker_reputation,
+        status.attacker_pair_count,
+    );
+
+    log::info!(
+        "Target has {}/{} pairs with reputation with its peers",
+        status.target_reputation,
+        status.target_pair_count,
+    );
+
     let attacker_threshold =
         status.attacker_pair_count * cli.attacker_reputation_percent as usize / 100;
     if status.attacker_reputation < attacker_threshold {


### PR DESCRIPTION
Current logging location duplicates this log on startup because we call it both in main and in our attack's reputation check.

Closes #50 