### PR TITLE
use buckets on incoming channel

### DIFF
--- a/ln-resource-mgr/src/forward_manager.rs
+++ b/ln-resource-mgr/src/forward_manager.rs
@@ -501,8 +501,12 @@ impl ReputationManager for ForwardManager {
 mod tests {
     use std::time::{Duration, Instant};
 
-    use super::RevenueAverage;
-    use crate::ReputationParams;
+    use super::{ForwardManagerParams, RevenueAverage};
+    use crate::{
+        forward_manager::{ForwardManager, SimualtionDebugManager},
+        AccountableSignal, ChannelSnapshot, HtlcRef, ProposedForward, ReputationError,
+        ReputationManager, ReputationParams,
+    };
 
     #[test]
     fn test_revenue_average() {
@@ -587,5 +591,132 @@ mod tests {
                 .unwrap(),
             (decayed_value as f64 / params.reputation_multiplier as f64).round() as i64,
         );
+    }
+
+    fn test_forward_manager_params() -> ForwardManagerParams {
+        ForwardManagerParams {
+            reputation_params: ReputationParams {
+                revenue_window: Duration::from_secs(60 * 60 * 24 * 14),
+                reputation_multiplier: 10,
+                resolution_period: Duration::from_secs(90),
+                expected_block_speed: None,
+            },
+            general_slot_portion: 30,
+            general_liquidity_portion: 30,
+            congestion_slot_portion: 20,
+            congestion_liquidity_portion: 20,
+        }
+    }
+
+    #[test]
+    fn test_add_and_remove_channel() {
+        let params = test_forward_manager_params();
+        let now = Instant::now();
+
+        let fwd_manager = ForwardManager::new(params);
+
+        let channel_capacity = 10_000_000;
+        assert!(fwd_manager
+            .add_channel(0, channel_capacity, now, None)
+            .is_ok());
+
+        // Test adding channel from a snapshot
+        let snapshot = ChannelSnapshot {
+            capacity_msat: 10_000_000,
+            outgoing_reputation: 1000,
+            bidirectional_revenue: 500,
+        };
+        assert!(fwd_manager
+            .add_channel(1, channel_capacity, now, Some(snapshot.clone()))
+            .is_ok());
+
+        assert!(
+            fwd_manager
+                .add_channel(0, channel_capacity, now, None)
+                .err()
+                .unwrap()
+                == ReputationError::ErrChannelExists(0)
+        );
+        assert!(
+            fwd_manager
+                .add_channel(5, 20_000_000, now, Some(snapshot))
+                .err()
+                .unwrap()
+                == ReputationError::ErrChannelCapacityMismatch(20_000_000, 10_000_000)
+        );
+
+        let channels = fwd_manager.list_channels(Instant::now()).unwrap();
+
+        assert!(channels.len() == 2);
+        assert!(channels.get(&0).unwrap().capacity_msat == channel_capacity);
+        // Check values on 2nd channel added from snapshot
+        assert!(channels.get(&1).unwrap().capacity_msat == channel_capacity);
+        assert!(channels.get(&1).unwrap().outgoing_reputation == 1000);
+        assert!(channels.get(&1).unwrap().bidirectional_revenue == 500);
+
+        assert!(fwd_manager.remove_channel(0).is_ok());
+        assert!(
+            fwd_manager.remove_channel(100).err().unwrap()
+                == ReputationError::ErrChannelNotFound(100)
+        )
+    }
+
+    fn test_proposed_forward(
+        incoming: u64,
+        outgoing: u64,
+        htlc_index: u64,
+        accountable: AccountableSignal,
+    ) -> ProposedForward {
+        ProposedForward {
+            incoming_ref: HtlcRef {
+                channel_id: incoming,
+                htlc_index,
+            },
+            outgoing_channel_id: outgoing,
+            amount_in_msat: 10_000,
+            amount_out_msat: 10_000 - 100,
+            expiry_in_height: 80,
+            expiry_out_height: 40,
+            added_at: Instant::now(),
+            incoming_accountable: accountable,
+            upgradable_accountability: true,
+        }
+    }
+
+    #[test]
+    fn test_add_htlc() {
+        let params = test_forward_manager_params();
+        let now = Instant::now();
+        let fwd_manager = ForwardManager::new(params);
+
+        let channel_capacity = 10_000_000;
+        fwd_manager
+            .add_channel(0, channel_capacity, now, None)
+            .unwrap();
+        fwd_manager
+            .add_channel(1, channel_capacity, now, None)
+            .unwrap();
+
+        let htlc_1 = test_proposed_forward(0, 1, 1, AccountableSignal::Unaccountable);
+
+        let fwd_outcome_check = fwd_manager.get_forwarding_outcome(&htlc_1).unwrap();
+        let check = fwd_manager.add_htlc(&htlc_1).unwrap();
+        // Sanity check that add_htlc and get_forwarding_outcome return same check for the same
+        // proposed forward.
+        assert_eq!(fwd_outcome_check, check);
+
+        let htlc_2 = test_proposed_forward(0, 1, 2, AccountableSignal::Unaccountable);
+        let check = fwd_manager.add_htlc(&htlc_2).unwrap();
+
+        // With general resources available, check that htlc_1 was added in general bucket
+        assert!(check.congestion_eligible);
+        assert!(check.resource_check.general_bucket.slots_used == 1);
+        assert!(check.resource_check.general_bucket.liquidity_used_msat == htlc_1.amount_in_msat);
+
+        // Jam the channel and try adding more htlcs.
+        fwd_manager.general_jam_channel(0).unwrap();
+
+        // TODO: when we implement the correct bucketing outcomes, expand this test to check htlcs
+        // are added in correct buckets.
     }
 }

--- a/ln-resource-mgr/src/forward_manager.rs
+++ b/ln-resource-mgr/src/forward_manager.rs
@@ -319,6 +319,13 @@ impl ReputationManager for ForwardManager {
 
                 let revenue = match &channel_reputation {
                     Some(channel) => {
+                        if channel.capacity_msat != capacity_msat {
+                            return Err(ReputationError::ErrChannelCapacityMismatch(
+                                capacity_msat,
+                                channel.capacity_msat,
+                            ));
+                        }
+
                         let mut revenue =
                             RevenueAverage::new(&self.params.reputation_params, add_ins);
                         revenue.add_value(channel.bidirectional_revenue, add_ins)?;

--- a/ln-resource-mgr/src/incoming_channel.rs
+++ b/ln-resource-mgr/src/incoming_channel.rs
@@ -1,101 +1,38 @@
-use std::time::Instant;
+/// Describes the size of a resource bucket.
+#[derive(Clone, Debug)]
+pub struct BucketParameters {
+    /// The number of HTLC slots available in the bucket.
+    pub slot_count: u16,
+    /// The amount of liquidity available in the bucket.
+    pub liquidity_msat: u64,
+}
 
-use crate::htlc_manager::InFlightHtlc;
-use crate::{ReputationParams, ResourceBucketType};
-
-/// Tracks information about the usage of the channels when it is utilized as the incoming direction in a htlc forward.
+/// Tracks resources available on the channel when it is utilized as the incoming direction in a htlc forward.
 #[derive(Debug)]
 pub(super) struct IncomingChannel {
-    params: ReputationParams,
-    /// Tracks the last instant that the incoming channel misused use of congested resources, if any.
-    last_congestion_misuse: Option<Instant>,
+    /// The resources available for htlcs that are not accountable, or are not sent by a peer with sufficient reputation.
+    pub(super) general_bucket: BucketParameters,
+
+    /// The resources available for htlcs that are accountable from peers that do not have sufficient reputation. This
+    /// bucket is only used when the general bucket is full, and peers are limited to a single slot/liquidity block.
+    pub(super) congestion_bucket: BucketParameters,
 }
 
 impl IncomingChannel {
-    pub(super) fn new(params: ReputationParams) -> Self {
+    pub(super) fn new(
+        general_bucket: BucketParameters,
+        congestion_bucket: BucketParameters,
+    ) -> Self {
         Self {
-            params,
-            last_congestion_misuse: None,
+            general_bucket,
+            congestion_bucket,
         }
     }
 
-    /// Returns true if the channel has never misused congestion resources, or sufficient time has passed since last
-    /// abuse (set by ReputationParams.revenue_window, as this is the period we can be jammed for).
-    pub(super) fn no_congestion_misuse(&self, access_ins: Instant) -> bool {
-        if let Some(instant) = self.last_congestion_misuse {
-            access_ins.duration_since(instant) > self.params.revenue_window
-        } else {
-            true
-        }
-    }
-
-    /// Resolves an in flight htlc, updating use of congestion resources to reflect misuse, if any.
-    pub(super) fn remove_incoming_htlc(&mut self, in_flight: &InFlightHtlc, resolved_ins: Instant) {
-        if in_flight.bucket == ResourceBucketType::Congestion
-            && resolved_ins.duration_since(in_flight.added_instant) >= self.params.resolution_period
-        {
-            self.last_congestion_misuse = Some(resolved_ins)
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::time::{Duration, Instant};
-
-    use super::IncomingChannel;
-    use crate::htlc_manager::InFlightHtlc;
-    use crate::{AccountableSignal, ReputationParams, ResourceBucketType};
-
-    #[test]
-    fn test_no_congestion_abuse() {
-        let now = Instant::now();
-        let params = ReputationParams {
-            revenue_window: Duration::from_secs(60 * 60 * 24 * 14),
-            reputation_multiplier: 12,
-            resolution_period: Duration::from_secs(90),
-            expected_block_speed: None,
+    pub(super) fn general_jam_channel(&mut self) {
+        self.general_bucket = BucketParameters {
+            slot_count: 0,
+            liquidity_msat: 0,
         };
-        let mut incoming_channel = IncomingChannel::new(params);
-
-        assert!(incoming_channel.no_congestion_misuse(now));
-
-        // Fast resolving HTLC does not trigger misuse.
-        incoming_channel.remove_incoming_htlc(
-            &InFlightHtlc {
-                outgoing_channel_id: 1,
-                fee_msat: 100,
-                hold_blocks: 40,
-                outgoing_amt_msat: 5000,
-                added_instant: now,
-                accountable: AccountableSignal::Accountable,
-                bucket: ResourceBucketType::Congestion,
-            },
-            now.checked_add(params.resolution_period / 2).unwrap(),
-        );
-        assert!(incoming_channel.no_congestion_misuse(now));
-
-        // Slow resolving HTLC does trigger misuse.
-        let last_misuse = now.checked_add(params.resolution_period * 2).unwrap();
-        incoming_channel.remove_incoming_htlc(
-            &InFlightHtlc {
-                outgoing_channel_id: 1,
-                fee_msat: 100,
-                hold_blocks: 40,
-                outgoing_amt_msat: 5000,
-                added_instant: now,
-                accountable: AccountableSignal::Accountable,
-                bucket: ResourceBucketType::Congestion,
-            },
-            last_misuse,
-        );
-        assert!(!incoming_channel.no_congestion_misuse(now));
-
-        // Only recover once the cooldown period has fully passed.
-        let half_recovered = last_misuse.checked_add(params.revenue_window / 2).unwrap();
-        assert!(!incoming_channel.no_congestion_misuse(half_recovered));
-
-        let fully_recovered = last_misuse.checked_add(params.revenue_window).unwrap();
-        assert!(!incoming_channel.no_congestion_misuse(fully_recovered));
     }
 }

--- a/ln-resource-mgr/src/incoming_channel.rs
+++ b/ln-resource-mgr/src/incoming_channel.rs
@@ -16,16 +16,22 @@ pub(super) struct IncomingChannel {
     /// The resources available for htlcs that are accountable from peers that do not have sufficient reputation. This
     /// bucket is only used when the general bucket is full, and peers are limited to a single slot/liquidity block.
     pub(super) congestion_bucket: BucketParameters,
+
+    /// The resources available on the protected bucket. This will be used by htlcs that are
+    /// accountable from peers that have sufficient reputation.
+    pub(super) protected_bucket: BucketParameters,
 }
 
 impl IncomingChannel {
     pub(super) fn new(
         general_bucket: BucketParameters,
         congestion_bucket: BucketParameters,
+        protected_bucket: BucketParameters,
     ) -> Self {
         Self {
             general_bucket,
             congestion_bucket,
+            protected_bucket,
         }
     }
 

--- a/ln-resource-mgr/src/lib.rs
+++ b/ln-resource-mgr/src/lib.rs
@@ -146,9 +146,9 @@ pub struct AllocationCheck {
     /// The reputation values used to compare the incoming channel's revenue to the outgoing channel's reputation for
     /// the htlc proposed.
     pub reputation_check: ReputationCheck,
-    /// Indicates whether the incoming channel is eligible to consume congestion resources.
+    /// Indicates whether the outgoing channel is eligible to consume congestion resources.
     pub congestion_eligible: bool,
-    /// The resources available on the outgoing channel.
+    /// The resources available on the incoming channel.
     pub resource_check: ResourceCheck,
 }
 

--- a/ln-resource-mgr/src/lib.rs
+++ b/ln-resource-mgr/src/lib.rs
@@ -300,6 +300,7 @@ impl ReputationCheck {
 pub struct ResourceCheck {
     pub general_bucket: BucketResources,
     pub congestion_bucket: BucketResources,
+    pub protected_bucket: BucketResources,
 }
 
 /// Describes the resources currently used in a bucket.
@@ -529,13 +530,19 @@ mod tests {
                     slots_used: 10,
                     slots_available: 10,
                     liquidity_used_msat: 0,
-                    liquidity_available_msat: 200_000,
+                    liquidity_available_msat: 200_000_000,
                 },
                 congestion_bucket: BucketResources {
                     slots_used: 0,
                     slots_available: 10,
                     liquidity_used_msat: 0,
                     liquidity_available_msat: MINIMUM_CONGESTION_SLOT_LIQUDITY * 20,
+                },
+                protected_bucket: BucketResources {
+                    slots_used: 0,
+                    slots_available: 10,
+                    liquidity_used_msat: 0,
+                    liquidity_available_msat: 300_000_000,
                 },
             },
         };

--- a/ln-resource-mgr/src/lib.rs
+++ b/ln-resource-mgr/src/lib.rs
@@ -44,6 +44,8 @@ pub enum ReputationError {
     ErrChannelExists(u64),
     /// Channel has already been removed or was never tracked.
     ErrChannelNotFound(u64),
+    /// Channel capacity does not match capacity in channel snapshot.
+    ErrChannelCapacityMismatch(u64, u64),
 }
 
 impl Error for ReputationError {}
@@ -92,6 +94,9 @@ impl Display for ReputationError {
             }
             ReputationError::ErrChannelNotFound(chan_id) => {
                 write!(f, "channel {chan_id} not found")
+            }
+            ReputationError::ErrChannelCapacityMismatch(capacity, snapshot_capacity) => {
+                write!(f, "channel capacity {capacity} does not match snapshot capacity {snapshot_capacity}")
             }
         }
     }

--- a/ln-simln-jamming/src/parsing.rs
+++ b/ln-simln-jamming/src/parsing.rs
@@ -60,7 +60,7 @@ pub const DEFAULT_ATTACKER_POLL_SECONDS: &str = "300";
 /// The default batch size for writing results to disk.
 pub const DEFAULT_RESULT_BATCH_SIZE: &str = "500";
 
-/// The default window that we consider revenue over (2 weeks = 60 * 60 * 24 * 7).
+/// The default window that we consider revenue over (2 weeks = 60 * 60 * 24 * 14).
 pub const DEFAULT_REVENUE_WINDOW_SECONDS: &str = "1210000";
 
 /// The default multiplier applied to the revenue window to get reputation window.

--- a/ln-simln-jamming/src/reputation_interceptor.rs
+++ b/ln-simln-jamming/src/reputation_interceptor.rs
@@ -1092,8 +1092,8 @@ mod tests {
         // unaccountable.
         let (request, mut receiver) = setup_test_request(
             edges[1].node_1.pubkey,
-            bob_to_carol,
             alice_to_bob,
+            bob_to_carol,
             AccountableSignal::Unaccountable,
         );
 
@@ -1106,8 +1106,8 @@ mod tests {
         // An unaccountable htlc using the jammed channel should be failed because there are no resources.
         let (request, mut receiver) = setup_test_request(
             edges[1].node_1.pubkey,
-            alice_to_bob,
             bob_to_carol,
+            alice_to_bob,
             AccountableSignal::Unaccountable,
         );
 

--- a/ln-simln-jamming/src/test_utils.rs
+++ b/ln-simln-jamming/src/test_utils.rs
@@ -108,6 +108,12 @@ pub fn test_allocation_check(forward_succeeds: bool) -> AllocationCheck {
                 liquidity_used_msat: 0,
                 liquidity_available_msat: 50_000,
             },
+            protected_bucket: BucketResources {
+                slots_used: 0,
+                slots_available: 10,
+                liquidity_used_msat: 0,
+                liquidity_available_msat: 100_000,
+            },
         },
     };
 


### PR DESCRIPTION
as part of https://github.com/carlaKC/jam-ln/issues/56, changed the bucketing to be applied on the incoming channel instead of outgoing. 

changes done:
- moved the bucket params from `OutgoingChannel` to `IncomingChannel`
- check misuse of congestion bucket on the outgoing channel instead of incoming
- added protected bucket to `IncomingChannel`
- slipped in a couple tests to `ForwardManager`

doing this before https://github.com/carlaKC/jam-ln/pull/62 so that I could add the protected bucket and use it for that PR. Also, the tests added in `ForwardManager` are incomplete but should be expanded on https://github.com/carlaKC/jam-ln/pull/62 when the correct bucketing outcomes are implemented. 