### PR TITLE
remove unused check_htlc_outcome

### DIFF
--- a/ln-simln-jamming/src/lib.rs
+++ b/ln-simln-jamming/src/lib.rs
@@ -177,13 +177,13 @@ fn print_request(req: &InterceptRequest) -> String {
 
 #[cfg(test)]
 mod tests {
-    use crate::reputation_interceptor::{HtlcAdd, ReputationMonitor};
+    use crate::reputation_interceptor::ReputationMonitor;
     use crate::test_utils::get_random_keypair;
     use crate::{count_reputation_pairs, get_network_reputation};
     use crate::{BoxError, NetworkReputation};
     use async_trait::async_trait;
     use bitcoin::secp256k1::PublicKey;
-    use ln_resource_mgr::{ChannelSnapshot, ForwardingOutcome, ReputationError};
+    use ln_resource_mgr::ChannelSnapshot;
     use mockall::mock;
     use std::collections::HashMap;
     use std::sync::Arc;
@@ -196,7 +196,6 @@ mod tests {
         #[async_trait]
         impl ReputationMonitor for Monitor{
             async fn list_channels(&self, node: PublicKey, access_ins: Instant) -> Result<HashMap<u64, ChannelSnapshot>, BoxError>;
-            async fn check_htlc_outcome(&self,htlc_add: HtlcAdd) -> Result<ForwardingOutcome, ReputationError>;
         }
     }
 

--- a/ln-simln-jamming/src/test_utils.rs
+++ b/ln-simln-jamming/src/test_utils.rs
@@ -2,14 +2,14 @@
 use std::error::Error;
 use std::time::Instant;
 
-use crate::reputation_interceptor::{BootstrapForward, HtlcAdd, ReputationMonitor};
+use crate::reputation_interceptor::{BootstrapForward, ReputationMonitor};
 use crate::{records_from_signal, BoxError};
 use async_trait::async_trait;
 use bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey};
 use lightning::ln::PaymentHash;
 use ln_resource_mgr::{
     AccountableSignal, AllocationCheck, BucketResources, ChannelSnapshot, ForwardingOutcome,
-    ProposedForward, ReputationCheck, ReputationError, ResourceCheck,
+    ProposedForward, ReputationCheck, ResourceCheck,
 };
 use mockall::mock;
 use rand::{distributions::Uniform, Rng};
@@ -33,7 +33,6 @@ mock! {
     #[async_trait]
     impl ReputationMonitor for ReputationInterceptor{
         async fn list_channels(&self, node: PublicKey, access_ins: Instant) -> Result<HashMap<u64, ChannelSnapshot>, BoxError>;
-        async fn check_htlc_outcome(&self,htlc_add: HtlcAdd) -> Result<ForwardingOutcome, ReputationError>;
     }
 }
 


### PR DESCRIPTION
I hope I'm not missing something but while doing some changes to the `ForwardManager` I noticed these methods were not used.  Perhaps they were added to help in testing? Anyhow, I think these are not needed but lmk if I'm wrong.

edit: Also looked into deleting `get_forwarding_outcome` on the `ReputationManager` which is also not used but I think could be. 