### PR TITLE
forward outcome from add_htlc

### DIFF
--- a/ln-resource-mgr/src/forward_manager.rs
+++ b/ln-resource-mgr/src/forward_manager.rs
@@ -145,7 +145,7 @@ struct ForwardManagerImpl {
 }
 
 impl ForwardManagerImpl {
-    fn get_forwarding_outcome(
+    fn get_allocation_snapshot(
         &mut self,
         forward: &ProposedForward,
     ) -> Result<AllocationCheck, ReputationError> {
@@ -375,14 +375,14 @@ impl ReputationManager for ForwardManager {
         }
     }
 
-    fn get_forwarding_outcome(
+    fn get_allocation_snapshot(
         &self,
         forward: &ProposedForward,
     ) -> Result<AllocationCheck, ReputationError> {
         self.inner
             .lock()
             .map_err(|e| ReputationError::ErrUnrecoverable(e.to_string()))?
-            .get_forwarding_outcome(forward)
+            .get_allocation_snapshot(forward)
     }
 
     fn add_htlc(&self, forward: &ProposedForward) -> Result<ForwardingOutcome, ReputationError> {
@@ -391,7 +391,7 @@ impl ReputationManager for ForwardManager {
             .lock()
             .map_err(|e| ReputationError::ErrUnrecoverable(e.to_string()))?;
 
-        let allocation_check = inner_lock.get_forwarding_outcome(forward)?;
+        let allocation_check = inner_lock.get_allocation_snapshot(forward)?;
 
         let fwd_outcome = allocation_check.inner_forwarding_outcome(
             forward.amount_out_msat,

--- a/ln-resource-mgr/src/forward_manager.rs
+++ b/ln-resource-mgr/src/forward_manager.rs
@@ -409,7 +409,7 @@ impl ReputationManager for ForwardManager {
                         incoming_amt_msat: forward.amount_in_msat,
                         fee_msat: forward.fee_msat(),
                         added_instant: forward.added_at,
-                        accountable: fwd_sucess.accountable_signal,
+                        outgoing_accountable: fwd_sucess.accountable_signal,
                         bucket: fwd_sucess.bucket,
                     },
                 )?;

--- a/ln-resource-mgr/src/forward_manager.rs
+++ b/ln-resource-mgr/src/forward_manager.rs
@@ -3,9 +3,9 @@ use crate::htlc_manager::{ChannelFilter, InFlightHtlc, InFlightManager};
 use crate::incoming_channel::{BucketParameters, IncomingChannel};
 use crate::outgoing_channel::OutgoingChannel;
 use crate::{
-    AllocationCheck, BucketResources, ChannelSnapshot, ForwardResolution, HtlcRef, ProposedForward,
-    ReputationCheck, ReputationError, ReputationManager, ReputationParams, ResourceBucketType,
-    ResourceCheck,
+    AllocationCheck, BucketResources, ChannelSnapshot, ForwardResolution, ForwardingOutcome,
+    HtlcRef, ProposedForward, ReputationCheck, ReputationError, ReputationManager,
+    ReputationParams, ResourceBucketType, ResourceCheck,
 };
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
@@ -385,7 +385,7 @@ impl ReputationManager for ForwardManager {
             .get_forwarding_outcome(forward)
     }
 
-    fn add_htlc(&self, forward: &ProposedForward) -> Result<AllocationCheck, ReputationError> {
+    fn add_htlc(&self, forward: &ProposedForward) -> Result<ForwardingOutcome, ReputationError> {
         let mut inner_lock = self
             .inner
             .lock()
@@ -393,26 +393,32 @@ impl ReputationManager for ForwardManager {
 
         let allocation_check = inner_lock.get_forwarding_outcome(forward)?;
 
-        if let Ok(bucket) = allocation_check.inner_forwarding_outcome(
+        let fwd_outcome = allocation_check.inner_forwarding_outcome(
             forward.amount_out_msat,
             forward.incoming_accountable,
             forward.upgradable_accountability,
-        ) {
-            inner_lock.htlcs.add_htlc(
-                forward.incoming_ref,
-                InFlightHtlc {
-                    outgoing_channel_id: forward.outgoing_channel_id,
-                    hold_blocks: forward.expiry_in_height,
-                    incoming_amt_msat: forward.amount_in_msat,
-                    fee_msat: forward.fee_msat(),
-                    added_instant: forward.added_at,
-                    accountable: forward.incoming_accountable,
-                    bucket,
-                },
-            )?;
-        }
+        );
 
-        Ok(allocation_check)
+        let fwd_outcome = match fwd_outcome {
+            Ok(fwd_sucess) => {
+                inner_lock.htlcs.add_htlc(
+                    forward.incoming_ref,
+                    InFlightHtlc {
+                        outgoing_channel_id: forward.outgoing_channel_id,
+                        hold_blocks: forward.expiry_in_height,
+                        incoming_amt_msat: forward.amount_in_msat,
+                        fee_msat: forward.fee_msat(),
+                        added_instant: forward.added_at,
+                        accountable: fwd_sucess.accountable_signal,
+                        bucket: fwd_sucess.bucket,
+                    },
+                )?;
+                ForwardingOutcome::Forward(fwd_sucess.accountable_signal)
+            }
+            Err(e) => ForwardingOutcome::Fail(e),
+        };
+
+        Ok(fwd_outcome)
     }
 
     fn resolve_htlc(
@@ -504,8 +510,8 @@ mod tests {
     use super::{ForwardManagerParams, RevenueAverage};
     use crate::{
         forward_manager::{ForwardManager, SimualtionDebugManager},
-        AccountableSignal, ChannelSnapshot, HtlcRef, ProposedForward, ReputationError,
-        ReputationManager, ReputationParams,
+        AccountableSignal, ChannelSnapshot, FailureReason, ForwardingOutcome, HtlcRef,
+        ProposedForward, ReputationError, ReputationManager, ReputationParams,
     };
 
     #[test]
@@ -684,7 +690,7 @@ mod tests {
     }
 
     #[test]
-    fn test_add_htlc() {
+    fn test_add_htlc_incoming_unaccountable() {
         let params = test_forward_manager_params();
         let now = Instant::now();
         let fwd_manager = ForwardManager::new(params);
@@ -698,25 +704,99 @@ mod tests {
             .unwrap();
 
         let htlc_1 = test_proposed_forward(0, 1, 1, AccountableSignal::Unaccountable);
+        let fwd_outcome = fwd_manager.add_htlc(&htlc_1).unwrap();
 
-        let fwd_outcome_check = fwd_manager.get_forwarding_outcome(&htlc_1).unwrap();
-        let check = fwd_manager.add_htlc(&htlc_1).unwrap();
-        // Sanity check that add_htlc and get_forwarding_outcome return same check for the same
-        // proposed forward.
-        assert_eq!(fwd_outcome_check, check);
-
-        let htlc_2 = test_proposed_forward(0, 1, 2, AccountableSignal::Unaccountable);
-        let check = fwd_manager.add_htlc(&htlc_2).unwrap();
-
-        // With general resources available, check that htlc_1 was added in general bucket
-        assert!(check.congestion_eligible);
-        assert!(check.resource_check.general_bucket.slots_used == 1);
-        assert!(check.resource_check.general_bucket.liquidity_used_msat == htlc_1.amount_in_msat);
+        // With general resources available, check that htlc_1 is forwarded as unaccountable.
+        assert!(fwd_outcome == ForwardingOutcome::Forward(AccountableSignal::Unaccountable));
 
         // Jam the channel and try adding more htlcs.
         fwd_manager.general_jam_channel(0).unwrap();
 
-        // TODO: when we implement the correct bucketing outcomes, expand this test to check htlcs
-        // are added in correct buckets.
+        // With no general resources available, unaccountable htlc should go into congestion bucket
+        // and be forwarded as accountable.
+        let htlc_2 = test_proposed_forward(0, 1, 2, AccountableSignal::Unaccountable);
+        let fwd_outcome = fwd_manager.add_htlc(&htlc_2).unwrap();
+        assert!(fwd_outcome == ForwardingOutcome::Forward(AccountableSignal::Accountable));
+
+        // Outgoing channel is already using a congestion slot, so it should fail with no resources
+        let htlc_3 = test_proposed_forward(0, 1, 3, AccountableSignal::Unaccountable);
+        let fwd_outcome = fwd_manager.add_htlc(&htlc_3).unwrap();
+        assert!(fwd_outcome == ForwardingOutcome::Fail(FailureReason::NoGeneralResources));
+
+        // Add a channel with sufficient reputation
+        let snapshot = ChannelSnapshot {
+            capacity_msat: channel_capacity,
+            outgoing_reputation: 10_000_000,
+            bidirectional_revenue: 1_000_000,
+        };
+        let channel_with_reputation = 2;
+
+        fwd_manager
+            .add_channel(
+                channel_with_reputation,
+                channel_capacity,
+                now,
+                Some(snapshot),
+            )
+            .unwrap();
+
+        // With general resources jammed, an unaccountable htlc for a peer with reputation is
+        // upgraded to accountable
+        let htlc_4 = test_proposed_forward(
+            0,
+            channel_with_reputation,
+            4,
+            AccountableSignal::Unaccountable,
+        );
+        let fwd_outcome = fwd_manager.add_htlc(&htlc_4).unwrap();
+        assert!(fwd_outcome == ForwardingOutcome::Forward(AccountableSignal::Accountable));
+    }
+
+    #[test]
+    fn test_add_htlc_incoming_accountable() {
+        let params = test_forward_manager_params();
+        let now = Instant::now();
+        let fwd_manager = ForwardManager::new(params);
+
+        let channel_capacity = 10_000_000;
+        fwd_manager
+            .add_channel(0, channel_capacity, now, None)
+            .unwrap();
+        fwd_manager
+            .add_channel(1, channel_capacity, now, None)
+            .unwrap();
+
+        let htlc_1 = test_proposed_forward(0, 1, 1, AccountableSignal::Accountable);
+        let fwd_outcome = fwd_manager.add_htlc(&htlc_1).unwrap();
+
+        // Accountable htlc for a peer with no reputation should fail
+        assert!(fwd_outcome == ForwardingOutcome::Fail(FailureReason::NoReputation));
+
+        // Add a channel with sufficient reputation
+        let snapshot = ChannelSnapshot {
+            capacity_msat: channel_capacity,
+            outgoing_reputation: 10_000_000,
+            bidirectional_revenue: 1_000_000,
+        };
+        let channel_with_reputation = 2;
+
+        fwd_manager
+            .add_channel(
+                channel_with_reputation,
+                channel_capacity,
+                now,
+                Some(snapshot),
+            )
+            .unwrap();
+
+        // Accountable htlc for a peer with reputation
+        let htlc_2 = test_proposed_forward(
+            0,
+            channel_with_reputation,
+            2,
+            AccountableSignal::Accountable,
+        );
+        let fwd_outcome = fwd_manager.add_htlc(&htlc_2).unwrap();
+        assert!(fwd_outcome == ForwardingOutcome::Forward(AccountableSignal::Accountable));
     }
 }

--- a/ln-resource-mgr/src/htlc_manager.rs
+++ b/ln-resource-mgr/src/htlc_manager.rs
@@ -11,7 +11,7 @@ pub(super) struct InFlightHtlc {
     pub(super) hold_blocks: u32,
     pub(super) incoming_amt_msat: u64,
     pub(super) added_instant: Instant,
-    pub(super) accountable: AccountableSignal,
+    pub(super) outgoing_accountable: AccountableSignal,
     pub(super) bucket: ResourceBucketType,
 }
 
@@ -129,7 +129,7 @@ impl InFlightManager {
             .iter()
             .filter(|(k, v)| {
                 // Unaccountable htlcs do not contribute to risk, so no option is given to count them.
-                if v.accountable == AccountableSignal::Unaccountable {
+                if v.outgoing_accountable == AccountableSignal::Unaccountable {
                     return false;
                 }
 
@@ -218,7 +218,7 @@ mod tests {
             incoming_amt_msat: 2000,
             fee_msat,
             added_instant: Instant::now(),
-            accountable: if accountable {
+            outgoing_accountable: if accountable {
                 AccountableSignal::Accountable
             } else {
                 AccountableSignal::Unaccountable

--- a/ln-resource-mgr/src/lib.rs
+++ b/ln-resource-mgr/src/lib.rs
@@ -542,7 +542,7 @@ pub trait ReputationManager {
     /// [`add_htlc`] before sending `update_add_htlc` on the outgoing link.
     /// NOTE: Use before [`add_htlc`]. The outcome will be different if the HTLC has already been
     /// added.
-    fn get_forwarding_outcome(
+    fn get_allocation_snapshot(
         &self,
         forward: &ProposedForward,
     ) -> Result<AllocationCheck, ReputationError>;

--- a/ln-resource-mgr/src/outgoing_channel.rs
+++ b/ln-resource-mgr/src/outgoing_channel.rs
@@ -85,7 +85,7 @@ impl OutgoingChannel {
         let effective_fees = self.params.effective_fees(
             in_flight.fee_msat,
             resolved_instant.sub(in_flight.added_instant),
-            in_flight.accountable,
+            in_flight.outgoing_accountable,
             settled,
         )?;
 
@@ -126,7 +126,7 @@ mod tests {
             incoming_amt_msat: 2000,
             fee_msat,
             added_instant: Instant::now(),
-            accountable,
+            outgoing_accountable: accountable,
             bucket,
         }
     }

--- a/ln-simln-jamming/src/analysis.rs
+++ b/ln-simln-jamming/src/analysis.rs
@@ -55,7 +55,7 @@ impl Serialize for Record {
             &self.decision.forwarding_outcome(
                 self.forward.amount_in_msat,
                 self.forward.incoming_accountable,
-                true,
+                self.forward.upgradable_accountability,
             ),
         )?;
         state.serialize_field(

--- a/ln-simln-jamming/src/reputation_interceptor.rs
+++ b/ln-simln-jamming/src/reputation_interceptor.rs
@@ -378,7 +378,7 @@ where
                 let node = e.get_mut();
                 (
                     node.forward_manager
-                        .get_forwarding_outcome(&htlc_add.htlc)?,
+                        .get_allocation_snapshot(&htlc_add.htlc)?,
                     node.forward_manager.add_htlc(&htlc_add.htlc)?,
                     node.alias.to_string(),
                 )
@@ -604,7 +604,7 @@ mod tests {
 
             fn remove_channel(&self, channel_id: u64) -> Result<(), ReputationError>;
 
-            fn get_forwarding_outcome(
+            fn get_allocation_snapshot(
                 &self,
                 forward: &ProposedForward,
             ) -> Result<AllocationCheck, ReputationError>;
@@ -731,7 +731,7 @@ mod tests {
             .get_mut(&pubkeys[0])
             .unwrap()
             .forward_manager
-            .expect_get_forwarding_outcome()
+            .expect_get_allocation_snapshot()
             .return_once(|_| Ok(test_allocation_check(true)));
 
         interceptor
@@ -764,7 +764,7 @@ mod tests {
             .get_mut(&pubkeys[0])
             .unwrap()
             .forward_manager
-            .expect_get_forwarding_outcome()
+            .expect_get_allocation_snapshot()
             .return_once(|_| Ok(test_allocation_check(true)));
 
         interceptor
@@ -799,7 +799,7 @@ mod tests {
             .get_mut(&pubkeys[0])
             .unwrap()
             .forward_manager
-            .expect_get_forwarding_outcome()
+            .expect_get_allocation_snapshot()
             .return_once(|_| Ok(test_allocation_check(false)));
 
         interceptor

--- a/ln-simln-jamming/src/reputation_interceptor.rs
+++ b/ln-simln-jamming/src/reputation_interceptor.rs
@@ -368,7 +368,7 @@ where
         report: bool,
     ) -> Result<Result<HashMap<u64, Vec<u8>>, ForwardingError>, ReputationError> {
         // If the forwarding node can't be found, we've hit a critical error and can't proceed.
-        let (allocation_check, alias) = match self
+        let (allocation_check, fwd_outcome, alias) = match self
             .network_nodes
             .lock()
             .await
@@ -377,6 +377,8 @@ where
             Entry::Occupied(mut e) => {
                 let node = e.get_mut();
                 (
+                    node.forward_manager
+                        .get_forwarding_outcome(&htlc_add.htlc)?,
                     node.forward_manager.add_htlc(&htlc_add.htlc)?,
                     node.alias.to_string(),
                 )
@@ -388,13 +390,6 @@ where
                 )))
             }
         };
-
-        // Once we have a forwarding decision, return successfully to the interceptor with the call.
-        let fwd_decision = allocation_check.forwarding_outcome(
-            htlc_add.htlc.amount_out_msat,
-            htlc_add.htlc.incoming_accountable,
-            htlc_add.htlc.upgradable_accountability,
-        );
 
         if let Some(r) = &self.results {
             if report {
@@ -413,12 +408,12 @@ where
             "Node {} forwarding: {} with outcome {}",
             alias,
             htlc_add.htlc,
-            fwd_decision,
+            fwd_outcome,
         );
 
-        match fwd_decision {
-            ForwardingOutcome::Forward(fwd_outcome) => {
-                Ok(Ok(records_from_signal(fwd_outcome.accountable_signal)))
+        match fwd_outcome {
+            ForwardingOutcome::Forward(accountable_signal) => {
+                Ok(Ok(records_from_signal(accountable_signal)))
             }
             ForwardingOutcome::Fail(reason) => Ok(Err(ForwardingError::InterceptorError(
                 reason.to_string().into(),
@@ -573,8 +568,8 @@ mod tests {
     use bitcoin::secp256k1::PublicKey;
     use ln_resource_mgr::forward_manager::{ForwardManager, ForwardManagerParams};
     use ln_resource_mgr::{
-        AccountableSignal, AllocationCheck, ChannelSnapshot, ForwardResolution, HtlcRef,
-        ProposedForward, ReputationError, ReputationManager, ReputationParams,
+        AccountableSignal, AllocationCheck, ChannelSnapshot, ForwardResolution, ForwardingOutcome,
+        HtlcRef, ProposedForward, ReputationError, ReputationManager, ReputationParams,
     };
     use mockall::mock;
     use simln_lib::clock::SimulationClock;
@@ -617,7 +612,7 @@ mod tests {
             fn add_htlc(
                 &self,
                 forward: &ProposedForward
-            ) -> Result<AllocationCheck, ReputationError>;
+            ) -> Result<ForwardingOutcome, ReputationError>;
             fn resolve_htlc(
                 &self,
                 outgoing_channel: u64,
@@ -736,8 +731,18 @@ mod tests {
             .get_mut(&pubkeys[0])
             .unwrap()
             .forward_manager
-            .expect_add_htlc()
+            .expect_get_forwarding_outcome()
             .return_once(|_| Ok(test_allocation_check(true)));
+
+        interceptor
+            .network_nodes
+            .lock()
+            .await
+            .get_mut(&pubkeys[0])
+            .unwrap()
+            .forward_manager
+            .expect_add_htlc()
+            .return_once(|_| Ok(ForwardingOutcome::Forward(AccountableSignal::Accountable)));
 
         interceptor.intercept_htlc(request).await;
 
@@ -759,14 +764,24 @@ mod tests {
             .get_mut(&pubkeys[0])
             .unwrap()
             .forward_manager
-            .expect_add_htlc()
+            .expect_get_forwarding_outcome()
             .return_once(|_| Ok(test_allocation_check(true)));
+
+        interceptor
+            .network_nodes
+            .lock()
+            .await
+            .get_mut(&pubkeys[0])
+            .unwrap()
+            .forward_manager
+            .expect_add_htlc()
+            .return_once(|_| Ok(ForwardingOutcome::Forward(AccountableSignal::Accountable)));
 
         interceptor.intercept_htlc(request).await;
 
         assert!(matches!(
             accountable_from_records(&receiver.recv().await.unwrap().unwrap().unwrap()),
-            AccountableSignal::Unaccountable
+            AccountableSignal::Accountable
         ));
     }
 
@@ -784,8 +799,18 @@ mod tests {
             .get_mut(&pubkeys[0])
             .unwrap()
             .forward_manager
-            .expect_add_htlc()
+            .expect_get_forwarding_outcome()
             .return_once(|_| Ok(test_allocation_check(false)));
+
+        interceptor
+            .network_nodes
+            .lock()
+            .await
+            .get_mut(&pubkeys[0])
+            .unwrap()
+            .forward_manager
+            .expect_add_htlc()
+            .return_once(|_| Ok(ForwardingOutcome::Forward(AccountableSignal::Unaccountable)));
 
         interceptor.intercept_htlc(request).await;
 

--- a/ln-simln-jamming/src/reputation_interceptor.rs
+++ b/ln-simln-jamming/src/reputation_interceptor.rs
@@ -417,7 +417,9 @@ where
         );
 
         match fwd_decision {
-            ForwardingOutcome::Forward(signal) => Ok(Ok(records_from_signal(signal))),
+            ForwardingOutcome::Forward(fwd_outcome) => {
+                Ok(Ok(records_from_signal(fwd_outcome.accountable_signal)))
+            }
             ForwardingOutcome::Fail(reason) => Ok(Err(ForwardingError::InterceptorError(
                 reason.to_string().into(),
             ))),


### PR DESCRIPTION
Returning both the accountable signal on the forward and the bucket where the htlc was assigned. This is needed because when adding an htlc with `add_htlc` we need to use the accountable signal on the outgoing forward instead of reusing the incoming one since the signal can be upgraded. 

This changed the API a bit on the return types from a couple of methods. Particularly on `add_htlc` it is returning the `ForwardingOutcome` instead of `AllocationCheck`. I think this better reflects the outcome of the method. If an `AllocationCheck` is needed, we can get it from `get_allocation_snapshot`. 

This also introduces changes to match the accountable signals that should forwarded based on the bucket and incoming signal as specified in the proposal. 

<s>Changes related to this PR are in last 3 commits. First 3 are from https://github.com/carlaKC/jam-ln/pull/62
TODOs: tests for `AllocationCheck`<s>