### PR TITLE
GeneralChannelJammer trait on the ReputationInterceptor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1439,7 +1439,7 @@ dependencies = [
  "ln-resource-mgr",
  "log",
  "mockall",
- "rand 0.8.5",
+ "rand 0.9.1",
  "serde",
  "serde_json",
  "sim-cli",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1432,7 +1432,6 @@ dependencies = [
  "bitcoin 0.30.2",
  "clap",
  "csv",
- "futures",
  "hex",
  "humantime",
  "lightning",

--- a/ln-resource-mgr/src/forward_manager.rs
+++ b/ln-resource-mgr/src/forward_manager.rs
@@ -127,7 +127,7 @@ impl ForwardManagerParams {
 }
 
 /// Defines special actions that can be taken during a simulation that wouldn't otherwise be used in regular operation.
-pub trait SimualtionDebugManager {
+pub trait SimulationDebugManager {
     fn general_jam_channel(&self, channel: u64) -> Result<(), ReputationError>;
 }
 
@@ -269,7 +269,7 @@ impl ForwardManager {
     }
 }
 
-impl SimualtionDebugManager for ForwardManager {
+impl SimulationDebugManager for ForwardManager {
     fn general_jam_channel(&self, channel: u64) -> Result<(), ReputationError> {
         self.inner
             .lock()
@@ -558,7 +558,7 @@ mod tests {
 
     use super::{ForwardManagerParams, RevenueAverage};
     use crate::{
-        forward_manager::{ForwardManager, SimualtionDebugManager},
+        forward_manager::{ForwardManager, SimulationDebugManager},
         AccountableSignal, ChannelSnapshot, FailureReason, ForwardingOutcome, HtlcRef,
         ProposedForward, ReputationError, ReputationManager, ReputationParams,
     };

--- a/ln-simln-jamming/Cargo.toml
+++ b/ln-simln-jamming/Cargo.toml
@@ -24,7 +24,6 @@ csv = "1.3.1"
 hex = "0.4.3"
 clap = { version = "4.0", features = ["derive"] }
 humantime = "2.1.0"
-futures = "0.3.31"
 rand = "0.9.1"
 mockall = "0.13.1"
 lightning = { version = "0.0.123" }

--- a/ln-simln-jamming/Cargo.toml
+++ b/ln-simln-jamming/Cargo.toml
@@ -25,7 +25,7 @@ hex = "0.4.3"
 clap = { version = "4.0", features = ["derive"] }
 humantime = "2.1.0"
 futures = "0.3.31"
-rand = "0.8.5"
+rand = "0.9.1"
 mockall = "0.13.1"
 lightning = { version = "0.0.123" }
 tokio-util = { version = "0.7.15", features = ["rt"] }

--- a/ln-simln-jamming/src/reputation_interceptor.rs
+++ b/ln-simln-jamming/src/reputation_interceptor.rs
@@ -4,7 +4,7 @@ use crate::{accountable_from_records, records_from_signal, upgradable_from_recor
 use async_trait::async_trait;
 use bitcoin::secp256k1::PublicKey;
 use ln_resource_mgr::forward_manager::{
-    ForwardManager, ForwardManagerParams, SimualtionDebugManager,
+    ForwardManager, ForwardManagerParams, SimulationDebugManager,
 };
 use ln_resource_mgr::{
     AccountableSignal, ChannelSnapshot, ForwardResolution, ForwardingOutcome, HtlcRef,

--- a/ln-simln-jamming/src/test_utils.rs
+++ b/ln-simln-jamming/src/test_utils.rs
@@ -11,7 +11,7 @@ use ln_resource_mgr::{
     ProposedForward, ReputationCheck, ResourceCheck,
 };
 use mockall::mock;
-use rand::{distributions::Uniform, Rng};
+use rand::Rng;
 use simln_lib::sim_node::{
     ChannelPolicy, CriticalError, CustomRecords, ForwardingError, InterceptRequest,
     InterceptResolution, Interceptor,
@@ -36,10 +36,10 @@ mock! {
 }
 
 pub fn get_random_bytes(size: usize) -> Vec<u8> {
-    rand::thread_rng()
-        .sample_iter(Uniform::new(u8::MIN, u8::MAX))
-        .take(size)
-        .collect()
+    let mut rng = rand::rng();
+    let mut bytes = vec![0u8; size];
+    rng.fill(&mut bytes[..]);
+    bytes.to_vec()
 }
 
 pub fn get_random_keypair() -> (SecretKey, PublicKey) {


### PR DESCRIPTION
very small  things I've stumbled upon while implementing a `JammingAttack`, mainly:
- <s> remove mutex on `reputation_interceptor` since `ReputationInterceptor` already mutexes on its fields.</s>
- add `GeneralChannelJammer` trait to jam a channel on a specific direction. 
- impl it on the `ReputationInterceptor`.  I think this is useful for jamming attacks that will like to jam a channel at any arbitrary point instead of only at the beginning