### PR TITLE
tools: Add forward generation tool for generating history

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,7 +135,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -146,7 +146,7 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -157,9 +157,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
@@ -364,9 +364,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.18.1"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytes"
@@ -376,9 +376,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.27"
+version = "1.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
+checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
 dependencies = [
  "shlex",
 ]
@@ -426,7 +426,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -616,7 +616,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -654,12 +654,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -803,7 +803,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -888,7 +888,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -897,9 +897,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
+checksum = "17da50a276f1e01e0ba6c029e47b7100754904ee8a278f886546e98575380785"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -907,7 +907,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.3.1",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1090,7 +1090,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.10",
+ "h2 0.4.11",
  "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
@@ -1161,9 +1161,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc2fdfdbff08affe55bb779f33b053aa1fe5dd5b54c257343c17edfa55711bdb"
+checksum = "7f66d5bd4c6f02bf0542fad85d626775bab9258cf795a4256dcaf3161114d1df"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1304,12 +1304,23 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.4",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -1376,9 +1387,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.173"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8cfeafaffdbc32176b64fb251369d52ea9f0a8fbc6f8759edffef7b525d64bb"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libm"
@@ -1536,7 +1547,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1666,7 +1677,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1677,9 +1688,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-src"
-version = "300.5.0+3.5.0"
+version = "300.5.1+3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8ce546f549326b0e6052b649198487d91320875da901e7bd11a06d1ee3f9c2f"
+checksum = "735230c832b28c000e3bc117119e6466a663ec73506bc0a9907ea4187508e42a"
 dependencies = [
  "cc",
 ]
@@ -1733,7 +1744,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
 ]
 
 [[package]]
@@ -1753,7 +1764,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1836,12 +1847,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6837b9e10d61f45f987d50808f83d1ee3d206c66acf650c3e4ae2e1f6ddedf55"
+checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
 dependencies = [
  "proc-macro2",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1908,11 +1919,11 @@ dependencies = [
  "multimap 0.10.1",
  "once_cell",
  "petgraph",
- "prettyplease 0.2.34",
+ "prettyplease 0.2.35",
  "prost 0.12.6",
  "prost-types 0.12.6",
  "regex",
- "syn 2.0.103",
+ "syn 2.0.104",
  "tempfile",
 ]
 
@@ -1939,7 +1950,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2123,16 +2134,16 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.20"
+version = "0.12.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabf4c97d9130e2bf606614eb937e86edac8292eaa6f422f995d7e8de1eb1813"
+checksum = "cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.4.10",
+ "h2 0.4.11",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
@@ -2428,7 +2439,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2488,7 +2499,7 @@ dependencies = [
 [[package]]
 name = "sim-cli"
 version = "0.1.1"
-source = "git+https://github.com/bitcoin-dev-project/sim-ln?rev=1fdcc849542ea4d05d8087c7f35d3145789956af#1fdcc849542ea4d05d8087c7f35d3145789956af"
+source = "git+https://github.com/bitcoin-dev-project/sim-ln?rev=b23aa5fcf14dac909f4eddffa1637d72dd777f15#b23aa5fcf14dac909f4eddffa1637d72dd777f15"
 dependencies = [
  "anyhow",
  "bitcoin 0.30.2",
@@ -2512,7 +2523,7 @@ dependencies = [
 [[package]]
 name = "simln-lib"
 version = "0.1.1"
-source = "git+https://github.com/bitcoin-dev-project/sim-ln?rev=1fdcc849542ea4d05d8087c7f35d3145789956af#1fdcc849542ea4d05d8087c7f35d3145789956af"
+source = "git+https://github.com/bitcoin-dev-project/sim-ln?rev=b23aa5fcf14dac909f4eddffa1637d72dd777f15#b23aa5fcf14dac909f4eddffa1637d72dd777f15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2631,9 +2642,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2663,7 +2674,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2723,7 +2734,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2771,17 +2782,19 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.45.1"
+version = "1.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
+checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
+ "slab",
  "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",
@@ -2805,7 +2818,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2959,11 +2972,11 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d021fc044c18582b9a2408cd0dd05b1596e3ecdb5c4df822bb0183545683889"
 dependencies = [
- "prettyplease 0.2.34",
+ "prettyplease 0.2.35",
  "proc-macro2",
  "prost-build 0.12.6",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3045,13 +3058,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1ffbcf9c6f6b99d386e7444eb608ba646ae452a36b39737deb9663b610f662"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3202,7 +3215,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
  "wasm-bindgen-shared",
 ]
 
@@ -3237,7 +3250,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3313,9 +3326,9 @@ checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-registry"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3bab093bdd303a1240bb99b8aba8ea8a69ee19d34c9e2ef9594e708a4878820"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
 dependencies = [
  "windows-link",
  "windows-result",
@@ -3368,6 +3381,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.2",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3391,11 +3413,27 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -3411,6 +3449,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3421,6 +3465,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3435,10 +3485,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3453,6 +3515,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3463,6 +3531,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3477,6 +3551,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3487,6 +3567,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "wit-bindgen-rt"
@@ -3523,28 +3609,28 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3564,7 +3650,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
  "synstructure",
 ]
 
@@ -3604,5 +3690,5 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ check: check-code stable-output
 
 install-tools:
 	cargo install --locked --path ln-simln-jamming --bin reputation-builder
+	cargo install --locked --path ln-simln-jamming --bin forward-builder
 
 install:
 	cargo install --locked --path ln-simln-jamming

--- a/ln-resource-mgr/src/forward_manager.rs
+++ b/ln-resource-mgr/src/forward_manager.rs
@@ -118,6 +118,23 @@ pub struct ForwardManagerParams {
     pub congestion_liquidity_portion: u8,
 }
 
+impl Default for ForwardManagerParams {
+    fn default() -> Self {
+        ForwardManagerParams {
+            reputation_params: ReputationParams {
+                revenue_window: Duration::from_secs(60 * 60 * 24 * 14),
+                reputation_multiplier: 12,
+                resolution_period: Duration::from_secs(90),
+                expected_block_speed: Some(Duration::from_secs(10 * 60)),
+            },
+            general_slot_portion: 30,
+            general_liquidity_portion: 30,
+            congestion_slot_portion: 20,
+            congestion_liquidity_portion: 20,
+        }
+    }
+}
+
 impl ForwardManagerParams {
     /// Returns the opportunity cost for the htlc amount and expiry provided, assuming 10 minute blocks.
     pub fn htlc_opportunity_cost(&self, fee_msat: u64, expiry: u32) -> u64 {

--- a/ln-resource-mgr/src/htlc_manager.rs
+++ b/ln-resource-mgr/src/htlc_manager.rs
@@ -67,6 +67,11 @@ impl ReputationParams {
 
         Ok(effective_fees)
     }
+
+    /// Returns the window over which reputation is assessed.
+    pub fn reputation_window(&self) -> Duration {
+        self.revenue_window * self.reputation_multiplier.into()
+    }
 }
 
 pub enum ChannelFilter {

--- a/ln-simln-jamming/Cargo.toml
+++ b/ln-simln-jamming/Cargo.toml
@@ -8,8 +8,8 @@ name = "reputation-builder"
 path = "src/bin/reputation_builder.rs"
 
 [dependencies]
-simln-lib = { git = "https://github.com/bitcoin-dev-project/sim-ln", rev = "1fdcc849542ea4d05d8087c7f35d3145789956af" }
-sim-cli = { git = "https://github.com/bitcoin-dev-project/sim-ln", rev = "1fdcc849542ea4d05d8087c7f35d3145789956af" }
+simln-lib = { git = "https://github.com/bitcoin-dev-project/sim-ln", rev = "b23aa5fcf14dac909f4eddffa1637d72dd777f15" }
+sim-cli = { git = "https://github.com/bitcoin-dev-project/sim-ln", rev = "b23aa5fcf14dac909f4eddffa1637d72dd777f15" }
 ln-resource-mgr = { path = "../ln-resource-mgr" }
 bitcoin = { version = "0.30.1" }
 async-trait = "0.1.73"

--- a/ln-simln-jamming/Cargo.toml
+++ b/ln-simln-jamming/Cargo.toml
@@ -7,6 +7,10 @@ edition = "2021"
 name = "reputation-builder"
 path = "src/bin/reputation_builder.rs"
 
+[[bin]]
+name = "forward-builder"
+path = "src/bin/forward_builder.rs"
+
 [dependencies]
 simln-lib = { git = "https://github.com/bitcoin-dev-project/sim-ln", rev = "b23aa5fcf14dac909f4eddffa1637d72dd777f15" }
 sim-cli = { git = "https://github.com/bitcoin-dev-project/sim-ln", rev = "b23aa5fcf14dac909f4eddffa1637d72dd777f15" }

--- a/ln-simln-jamming/src/bin/forward_builder.rs
+++ b/ln-simln-jamming/src/bin/forward_builder.rs
@@ -1,0 +1,183 @@
+use async_trait::async_trait;
+use bitcoin::secp256k1::PublicKey;
+use clap::Parser;
+use ln_resource_mgr::{AllocationCheck, ProposedForward};
+use ln_simln_jamming::analysis::ForwardReporter;
+use ln_simln_jamming::clock::InstantClock;
+use ln_simln_jamming::parsing::{
+    find_pubkey_by_alias, parse_duration, ReputationParams, SimNetwork, DEFAULT_REPUTATION_DIR,
+    DEFAULT_SIM_FILE,
+};
+use ln_simln_jamming::reputation_interceptor::{BootstrapForward, ReputationInterceptor};
+use ln_simln_jamming::{BoxError, ACCOUNTABLE_TYPE, UPGRADABLE_TYPE};
+use log::LevelFilter;
+use sim_cli::parsing::{create_simulation_with_network, SimParams};
+use simln_lib::batched_writer::BatchedWriter;
+use simln_lib::clock::{Clock, SimulationClock};
+use simln_lib::latency_interceptor::LatencyIntercepor;
+use simln_lib::sim_node::CustomRecords;
+use simln_lib::SimulationCfg;
+use simple_logger::SimpleLogger;
+use std::fs;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::{Duration, UNIX_EPOCH};
+use tokio::sync::Mutex;
+use tokio_util::task::TaskTracker;
+
+// The default filename for the output.
+pub const DEFAULT_FWD_FILE: &str = "forwards.csv";
+
+// The default amount of time data will be generated for.
+pub const DEFAULT_RUNTIME: &str = "6months";
+
+#[derive(Parser)]
+struct Cli {
+    /// A json file describing the lightning channels being simulated.
+    #[arg(long, short, default_value = DEFAULT_SIM_FILE)]
+    sim_file: PathBuf,
+
+    // The directory to write the output to.
+    #[arg(long, short, default_value = DEFAULT_REPUTATION_DIR)]
+    output_dir: PathBuf,
+
+    /// The amount of time to generate forwarding history for.
+    #[arg(long, value_parser = parse_duration, default_value = DEFAULT_RUNTIME)]
+    pub duration: (String, Duration),
+
+    /// The alias of the target node.
+    #[arg(long)]
+    pub target_alias: String,
+
+    /// The alias of the attacking node.
+    #[arg(long)]
+    pub attacker_alias: String,
+
+    #[command(flatten)]
+    pub reputation_params: ReputationParams,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), BoxError> {
+    SimpleLogger::new()
+        .with_level(LevelFilter::Debug)
+        // Lower logging from sim-ln so that we can focus on our own logs.
+        .with_module_level("simln_lib", LevelFilter::Info)
+        .with_module_level("sim_cli", LevelFilter::Off)
+        // Debug so that we can read interceptor-related logging.
+        .with_module_level("simln_lib::sim_node", LevelFilter::Debug)
+        .init()
+        .unwrap();
+
+    let cli = Cli::parse();
+    let SimNetwork { sim_network } =
+        serde_json::from_str(&fs::read_to_string(cli.sim_file.as_path())?)?;
+
+    log::info!("Generating history for: {}", cli.duration.0);
+
+    let target_pubkey = find_pubkey_by_alias(&cli.target_alias, &sim_network)?;
+    let attacker_pubkey = find_pubkey_by_alias(&cli.attacker_alias, &sim_network)?;
+
+    let clock = Arc::new(SimulationClock::new(500)?);
+    let tasks = TaskTracker::new();
+
+    // Create a reputation interceptor without any bootstrap (since here we're creating the
+    // bootstrap itself, we just want to run with reputation active).
+    let reputation_interceptor = Arc::new(ReputationInterceptor::new_for_network(
+        cli.reputation_params.into(),
+        &sim_network,
+        clock.clone(),
+        Some(Arc::new(Mutex::new(BootstrapWriter::new(
+            clock.clone(),
+            cli.output_dir,
+        )?))),
+    )?);
+    let latency_interceptor = Arc::new(LatencyIntercepor::new_poisson(300.0)?);
+
+    let sim_cfg = SimulationCfg::new(
+        Some(cli.duration.1.as_secs() as u32),
+        3_800_000,
+        2.0,
+        None,
+        Some(13995354354227336701),
+    );
+
+    let custom_records =
+        CustomRecords::from([(UPGRADABLE_TYPE, vec![1]), (ACCOUNTABLE_TYPE, vec![0])]);
+
+    let sim_params = SimParams {
+        nodes: vec![],
+        sim_network,
+        activity: vec![],
+        exclude: vec![attacker_pubkey, target_pubkey],
+    };
+
+    let (simulation, validated_activities, _sim_nodes) = create_simulation_with_network(
+        sim_cfg,
+        &sim_params,
+        clock,
+        tasks,
+        vec![reputation_interceptor, latency_interceptor],
+        custom_records,
+    )
+    .await?;
+
+    simulation.run(&validated_activities).await?;
+
+    Ok(())
+}
+
+// Writes all forwards to disk in batches.
+struct BootstrapWriter<C> {
+    clock: Arc<C>,
+    batch_writer: Mutex<BatchedWriter>,
+}
+
+impl<C> BootstrapWriter<C>
+where
+    C: Clock + InstantClock + Send + Sync,
+{
+    fn new(clock: Arc<C>, dir: PathBuf) -> Result<Self, BoxError> {
+        Ok(BootstrapWriter {
+            clock,
+            batch_writer: Mutex::new(BatchedWriter::new(dir, DEFAULT_FWD_FILE.into(), 500)?),
+        })
+    }
+}
+
+#[async_trait]
+impl<C> ForwardReporter for BootstrapWriter<C>
+where
+    C: Clock + InstantClock + Send + Sync,
+{
+    async fn report_forward(
+        &mut self,
+        forwarding_node: PublicKey,
+        _: AllocationCheck,
+        forward: ProposedForward,
+    ) -> Result<(), BoxError> {
+        let settled_ns = Clock::now(&*self.clock)
+            .duration_since(UNIX_EPOCH)?
+            .as_nanos() as u64;
+
+        let nanos_since_added = InstantClock::now(&*self.clock)
+            .duration_since(forward.added_at)
+            .as_nanos() as u64;
+
+        self.batch_writer
+            .lock()
+            .await
+            .queue(BootstrapForward {
+                incoming_amt: forward.amount_in_msat,
+                outgoing_amt: forward.amount_out_msat,
+                incoming_expiry: forward.expiry_in_height,
+                outgoing_expiry: forward.expiry_out_height,
+                added_ns: settled_ns - nanos_since_added,
+                settled_ns,
+                forwarding_node,
+                channel_in_id: forward.incoming_ref.channel_id,
+                channel_out_id: forward.outgoing_channel_id,
+            })
+            .map_err(|e| e.into())
+    }
+}

--- a/ln-simln-jamming/src/main.rs
+++ b/ln-simln-jamming/src/main.rs
@@ -1,8 +1,6 @@
 use bitcoin::secp256k1::PublicKey;
 use clap::Parser;
 use core::panic;
-use ln_resource_mgr::forward_manager::ForwardManagerParams;
-use ln_resource_mgr::ReputationParams;
 use ln_simln_jamming::analysis::BatchForwardWriter;
 use ln_simln_jamming::attack_interceptor::AttackInterceptor;
 use ln_simln_jamming::attacks::sink::SinkAttack;
@@ -48,7 +46,7 @@ async fn main() -> Result<(), BoxError> {
         .unwrap();
 
     let cli = Cli::parse();
-    cli.validate()?;
+    let forward_params = cli.validate()?;
 
     let SimNetwork { sim_network } =
         serde_json::from_str(&fs::read_to_string(cli.sim_file.as_path())?)?;
@@ -87,18 +85,6 @@ async fn main() -> Result<(), BoxError> {
         Arc::new(LatencyIntercepor::new_poisson(150.0)?);
 
     let now = InstantClock::now(&*clock);
-    let forward_params = ForwardManagerParams {
-        reputation_params: ReputationParams {
-            revenue_window: Duration::from_secs(cli.revenue_window_seconds),
-            reputation_multiplier: cli.reputation_multiplier,
-            resolution_period: Duration::from_secs(90),
-            expected_block_speed: Some(Duration::from_secs(10 * 60)),
-        },
-        general_slot_portion: 30,
-        general_liquidity_portion: 30,
-        congestion_slot_portion: 20,
-        congestion_liquidity_portion: 20,
-    };
 
     // Create a writer to store results for nodes that we care about.
     let monitor_channels: Vec<(PublicKey, String)> = target_channels.values().cloned().collect();

--- a/ln-simln-jamming/src/parsing.rs
+++ b/ln-simln-jamming/src/parsing.rs
@@ -5,6 +5,7 @@ use bitcoin::secp256k1::PublicKey;
 use clap::Parser;
 use csv::{ReaderBuilder, StringRecord};
 use humantime::Duration as HumanDuration;
+use ln_resource_mgr::forward_manager::ForwardManagerParams;
 use ln_resource_mgr::ChannelSnapshot;
 use serde::{Deserialize, Serialize};
 use sim_cli::parsing::NetworkParser;
@@ -60,14 +61,32 @@ pub const DEFAULT_ATTACKER_POLL_SECONDS: &str = "300";
 /// The default batch size for writing results to disk.
 pub const DEFAULT_RESULT_BATCH_SIZE: &str = "500";
 
-/// The default window that we consider revenue over (2 weeks = 60 * 60 * 24 * 14).
-pub const DEFAULT_REVENUE_WINDOW_SECONDS: &str = "1210000";
-
-/// The default multiplier applied to the revenue window to get reputation window.
-pub const DEFAULT_REPUTATION_MULTIPLIER: &str = "12";
-
 /// The default location to output results files.
 const DEFAULT_RESULTS_DIR: &str = ".";
+
+#[derive(Clone, Parser)]
+pub struct ReputationParams {
+    /// The window over which the value of a link's revenue to our node is calculated.
+    #[arg(long)]
+    pub revenue_window_seconds: Option<u64>,
+
+    /// The multiplier applied to revenue_window_seconds to get the duration over which reputation is bootstrapped.
+    #[arg(long)]
+    pub reputation_multiplier: Option<u8>,
+}
+
+impl From<ReputationParams> for ForwardManagerParams {
+    fn from(cli: ReputationParams) -> Self {
+        let mut forward_params = ForwardManagerParams::default();
+        if let Some(revenue_window) = cli.revenue_window_seconds {
+            forward_params.reputation_params.revenue_window = Duration::from_secs(revenue_window);
+        }
+        if let Some(multiplier) = cli.reputation_multiplier {
+            forward_params.reputation_params.reputation_multiplier = multiplier;
+        }
+        forward_params
+    }
+}
 
 #[derive(Parser)]
 #[command(version, about)]
@@ -123,13 +142,8 @@ pub struct Cli {
     #[arg(long, default_value = DEFAULT_RESULT_BATCH_SIZE)]
     pub result_batch_size: u16,
 
-    /// The window over which the value of a link's revenue to our node is calculated.
-    #[arg(long, default_value = DEFAULT_REVENUE_WINDOW_SECONDS)]
-    pub revenue_window_seconds: u64,
-
-    /// The multiplier applied to revenue_window_seconds to get the duration over which reputation is bootstrapped.
-    #[arg(long, default_value = DEFAULT_REPUTATION_MULTIPLIER)]
-    pub reputation_multiplier: u8,
+    #[command(flatten)]
+    pub reputation_params: ReputationParams,
 
     /// The directory to write output files to.
     #[arg(long, default_value = DEFAULT_RESULTS_DIR)]
@@ -145,7 +159,7 @@ pub struct Cli {
 }
 
 impl Cli {
-    pub fn validate(&self) -> Result<(), BoxError> {
+    pub fn validate(&self) -> Result<ForwardManagerParams, BoxError> {
         if self.target_reputation_percent == 0 || self.target_reputation_percent > 100 {
             return Err(format!(
                 "target reputation percent {} must be in (0;100]",
@@ -162,22 +176,19 @@ impl Cli {
             .into());
         }
 
-        if self.reputation_window() < self.attacker_bootstrap.1 {
+        let forward_params: ForwardManagerParams = self.reputation_params.clone().into();
+        if forward_params.reputation_params.reputation_window() < self.attacker_bootstrap.1 {
             return Err(format!(
-                "attacker_bootstrap {:?} < reputation window {:?} ({} * {})))",
-                self.attacker_bootstrap,
-                self.reputation_window(),
-                self.revenue_window_seconds,
-                self.reputation_multiplier,
+                "attacker_bootstrap {:?} < reputation window {:?} ({:?} * {})))",
+                self.attacker_bootstrap.1,
+                forward_params.reputation_params.reputation_window(),
+                forward_params.reputation_params.revenue_window,
+                forward_params.reputation_params.reputation_multiplier,
             )
             .into());
         }
 
-        Ok(())
-    }
-
-    pub fn reputation_window(&self) -> Duration {
-        Duration::from_secs(self.revenue_window_seconds * self.reputation_multiplier as u64)
+        Ok(forward_params)
     }
 }
 

--- a/ln-simln-jamming/src/reputation_interceptor.rs
+++ b/ln-simln-jamming/src/reputation_interceptor.rs
@@ -410,6 +410,7 @@ where
                         allocation_check,
                         htlc_add.htlc.clone(),
                     )
+                    .await
                     .map_err(|e| ReputationError::ErrUnrecoverable(e.to_string()))?;
             }
         }

--- a/ln-simln-jamming/src/reputation_interceptor.rs
+++ b/ln-simln-jamming/src/reputation_interceptor.rs
@@ -10,7 +10,7 @@ use ln_resource_mgr::{
     AccountableSignal, ChannelSnapshot, ForwardResolution, ForwardingOutcome, HtlcRef,
     ProposedForward, ReputationError, ReputationManager,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use sim_cli::parsing::NetworkParser;
 use simln_lib::sim_node::{
     CriticalError, CustomRecords, ForwardingError, InterceptRequest, InterceptResolution,
@@ -48,7 +48,7 @@ pub struct BootstrapRecords {
 }
 
 /// Provides details of a htlc forward that is used to bootstrap reputation values for the network.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct BootstrapForward {
     pub incoming_amt: u64,
     pub outgoing_amt: u64,

--- a/ln-simln-jamming/src/reputation_interceptor.rs
+++ b/ln-simln-jamming/src/reputation_interceptor.rs
@@ -10,6 +10,7 @@ use ln_resource_mgr::{
     AccountableSignal, ChannelSnapshot, ForwardResolution, ForwardingOutcome, HtlcRef,
     ProposedForward, ReputationError, ReputationManager,
 };
+use serde::Serialize;
 use sim_cli::parsing::NetworkParser;
 use simln_lib::sim_node::{
     CriticalError, CustomRecords, ForwardingError, InterceptRequest, InterceptResolution,
@@ -47,7 +48,7 @@ pub struct BootstrapRecords {
 }
 
 /// Provides details of a htlc forward that is used to bootstrap reputation values for the network.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct BootstrapForward {
     pub incoming_amt: u64,
     pub outgoing_amt: u64,


### PR DESCRIPTION
Add a new tool that can produce a single file with all forwards for the graph provided to bootstrap reputation. This can be paired with `reputation-builder` to generate summaries of the forwarding data for different bootstrap periods.