### PR TITLE
ln-simln-jamming: add attacker receive interceptor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2488,7 +2488,7 @@ dependencies = [
 [[package]]
 name = "sim-cli"
 version = "0.1.1"
-source = "git+https://github.com/bitcoin-dev-project/sim-ln?rev=49d5ae439c646132872c66e74408eebd4b2d30f1#49d5ae439c646132872c66e74408eebd4b2d30f1"
+source = "git+https://github.com/bitcoin-dev-project/sim-ln?rev=1fdcc849542ea4d05d8087c7f35d3145789956af#1fdcc849542ea4d05d8087c7f35d3145789956af"
 dependencies = [
  "anyhow",
  "bitcoin 0.30.2",
@@ -2512,7 +2512,7 @@ dependencies = [
 [[package]]
 name = "simln-lib"
 version = "0.1.1"
-source = "git+https://github.com/bitcoin-dev-project/sim-ln?rev=49d5ae439c646132872c66e74408eebd4b2d30f1#49d5ae439c646132872c66e74408eebd4b2d30f1"
+source = "git+https://github.com/bitcoin-dev-project/sim-ln?rev=1fdcc849542ea4d05d8087c7f35d3145789956af#1fdcc849542ea4d05d8087c7f35d3145789956af"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/ln-simln-jamming/Cargo.toml
+++ b/ln-simln-jamming/Cargo.toml
@@ -8,8 +8,8 @@ name = "reputation-builder"
 path = "src/bin/reputation_builder.rs"
 
 [dependencies]
-simln-lib = { git = "https://github.com/bitcoin-dev-project/sim-ln", rev = "49d5ae439c646132872c66e74408eebd4b2d30f1" }
-sim-cli = { git = "https://github.com/bitcoin-dev-project/sim-ln", rev = "49d5ae439c646132872c66e74408eebd4b2d30f1" }
+simln-lib = { git = "https://github.com/bitcoin-dev-project/sim-ln", rev = "1fdcc849542ea4d05d8087c7f35d3145789956af" }
+sim-cli = { git = "https://github.com/bitcoin-dev-project/sim-ln", rev = "1fdcc849542ea4d05d8087c7f35d3145789956af" }
 ln-resource-mgr = { path = "../ln-resource-mgr" }
 bitcoin = { version = "0.30.1" }
 async-trait = "0.1.73"

--- a/ln-simln-jamming/src/attacks/sink.rs
+++ b/ln-simln-jamming/src/attacks/sink.rs
@@ -186,6 +186,8 @@ where
         })
     }
 
+    /// Intercepts attacker forwads from the target node to jam them, otherwise forwards unrelated
+    /// traffic in the hopes of continuing to be chosen in pathfinding (it can't hurt).
     async fn intercept_attacker_htlc(
         &self,
         req: InterceptRequest,
@@ -220,6 +222,15 @@ where
         Ok(Ok(records_from_signal(accountable_from_records(
             &req.incoming_custom_records,
         ))))
+    }
+
+    /// Errors if called, because sink attacks rely on passive payment forwarding and should not
+    /// receive any payments themselves.
+    async fn intercept_attacker_receive(
+        &self,
+        _req: InterceptRequest,
+    ) -> Result<Result<CustomRecords, ForwardingError>, BoxError> {
+        return Err("HTLC receive not expected in passive sink attack".into());
     }
 
     async fn simulation_completed(

--- a/ln-simln-jamming/src/main.rs
+++ b/ln-simln-jamming/src/main.rs
@@ -284,7 +284,7 @@ async fn main() -> Result<(), BoxError> {
     let (simulation, validated_activities, sim_nodes) = create_simulation_with_network(
         sim_cfg,
         &sim_params,
-        cli.clock_speedup,
+        clock.clone(),
         tasks,
         interceptors,
         custom_records,

--- a/ln-simln-jamming/src/main.rs
+++ b/ln-simln-jamming/src/main.rs
@@ -277,7 +277,7 @@ async fn main() -> Result<(), BoxError> {
         nodes: vec![],
         sim_network,
         activity: vec![],
-        exclude: vec![],
+        exclude: vec![attacker_pubkey, target_pubkey],
     };
 
     let sim_cfg = SimulationCfg::new(None, 3_800_000, 2.0, None, Some(13995354354227336701));


### PR DESCRIPTION
Improve separation of concerns for attack implementations - generally the actions taken for forwards will be different to receives, so we split them up to save implementations from having to branch all their logic on whether it's a forward or not.