### PR TITLE
reputation builder helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1439,7 +1439,7 @@ dependencies = [
  "ln-resource-mgr",
  "log",
  "mockall",
- "rand 0.8.5",
+ "rand 0.9.1",
  "serde",
  "serde_json",
  "sim-cli",

--- a/ln-simln-jamming/Cargo.toml
+++ b/ln-simln-jamming/Cargo.toml
@@ -25,7 +25,7 @@ hex = "0.4.3"
 clap = { version = "4.0", features = ["derive"] }
 humantime = "2.1.0"
 futures = "0.3.31"
-rand = "0.8.5"
+rand = "0.9.1"
 mockall = "0.13.1"
 lightning = { version = "0.0.123" }
 tokio-util = { version = "0.7.15", features = ["rt"] }

--- a/ln-simln-jamming/src/attacks/utils.rs
+++ b/ln-simln-jamming/src/attacks/utils.rs
@@ -1,12 +1,21 @@
+use std::{collections::HashMap, sync::Arc};
+
 use bitcoin::secp256k1::PublicKey;
 use lightning::{
-    ln::msgs::LightningError,
+    ln::{msgs::LightningError, PaymentHash},
     routing::{
         gossip::NetworkGraph,
         router::{build_route_from_hops, PaymentParameters, Route, RouteParameters},
     },
 };
-use simln_lib::sim_node::WrappedLog;
+use rand::Rng;
+use simln_lib::{
+    clock::Clock,
+    sim_node::{SimGraph, SimNode, WrappedLog},
+};
+use tokio::sync::Mutex;
+
+use crate::{clock::InstantClock, reputation_interceptor::ReputationMonitor, BoxError};
 
 pub fn build_custom_route(
     sender: &PublicKey,
@@ -31,4 +40,65 @@ pub fn build_custom_route(
         &WrappedLog {},
         &[0; 32],
     )
+}
+
+/// Helper to build reputation for a specific incoming channel (target_channel)
+/// by sending a batch of payments. The `routes` param is a map from sender node public keys to their
+/// respective `Route`. This allows for building reputation from multiple senders e.g:
+///
+/// - Route 1: A → B → C
+/// - Route 2: D → B → C
+///
+/// In both cases, the channel B <-> C is the outgoing channel for the last hop, and both senders
+/// (A and D) will send payments through this channel.
+///
+/// The `target_channel` is channel for which reputation is being built. Here we should monitor the
+/// outgoing channel reputation against the target_channel revenue.
+pub async fn build_reputation<C: Clock + InstantClock, R: ReputationMonitor>(
+    attacker_nodes: HashMap<PublicKey, Arc<Mutex<SimNode<SimGraph>>>>,
+    routes: HashMap<PublicKey, Route>,
+    target_channel: (PublicKey, u64),
+    reputation_monitor: Arc<R>,
+    clock: Arc<C>,
+) -> Result<u64, BoxError> {
+    let batch_payments = 20;
+    let mut total_fees_paid = 0;
+
+    for (sender, route) in routes {
+        let sender_node = attacker_nodes.get(&sender).ok_or(format!(
+            "sender {} not found in attacker_nodes",
+            sender.to_string()
+        ))?;
+
+        let mut sender_node = sender_node.lock().await;
+        for _ in 0..batch_payments {
+            let hash = PaymentHash(get_random_bytes());
+            if let Err(e) = sender_node.send_to_route(route.clone(), hash, None).await {
+                return Err(e.to_string().into());
+            }
+        }
+
+        let last_hop_channel = route.paths[0].hops.last().unwrap().short_channel_id;
+        let target_channels = reputation_monitor
+            .list_channels(target_channel.0, InstantClock::now(&*clock))
+            .await
+            .unwrap();
+
+        let reputation_target_channel = target_channels.get(&target_channel.1).unwrap();
+        let outgoing_channel = target_channels.get(&last_hop_channel).unwrap();
+
+        // TODO: include in-flight htlc risk
+        if outgoing_channel.outgoing_reputation >= reputation_target_channel.bidirectional_revenue {
+            println!("FINISHED BUILDING REPUTATION!");
+        }
+    }
+
+    Ok(total_fees_paid)
+}
+
+pub fn get_random_bytes() -> [u8; 32] {
+    let mut rng = rand::rng();
+    let mut bytes = [0u8; 32];
+    rng.fill(&mut bytes[..]);
+    bytes
 }

--- a/ln-simln-jamming/src/test_utils.rs
+++ b/ln-simln-jamming/src/test_utils.rs
@@ -11,7 +11,7 @@ use ln_resource_mgr::{
     ProposedForward, ReputationCheck, ResourceCheck,
 };
 use mockall::mock;
-use rand::{distributions::Uniform, Rng};
+use rand::Rng;
 use simln_lib::sim_node::{
     ChannelPolicy, CriticalError, CustomRecords, ForwardingError, InterceptRequest,
     InterceptResolution, Interceptor,
@@ -36,10 +36,10 @@ mock! {
 }
 
 pub fn get_random_bytes(size: usize) -> Vec<u8> {
-    rand::thread_rng()
-        .sample_iter(Uniform::new(u8::MIN, u8::MAX))
-        .take(size)
-        .collect()
+    let mut rng = rand::rng();
+    let mut bytes = vec![0u8; size];
+    rng.fill(&mut bytes[..]);
+    bytes.to_vec()
 }
 
 pub fn get_random_keypair() -> (SecretKey, PublicKey) {


### PR DESCRIPTION
Please pardon the incredibly badly written code. Was just throwing unwraps everywhere.

Mostly wondering about `build_reputation` and if this is what you had in mind for the "prepay" reputation helper? 

`build_reputation` will allow an attack to specify multiple senders to help build reputation for one outgoing channel i.e something like (to build reputation over B <-> C):
- Route 1: A → B → C
- Route 2: D → B → C 

Up to the attack implementation as it can only do 1 or many senders. This should then monitor `C's` reputation over `B <-> C` against the `target_channel` passed. 

What I'm still wondering: 
- when should we stop trying to build reputation? With `track_payment` is kind of tricky but maybe some background task that will continuously loop to check outcome of payments we have sent in the batch. Depending on outcome (if there was a payment failure from `track_payment` - need to check for a specific error (?) ) return an error? if payment successful will somehow need to add it to a running total of fees to know how much we paid to build reputation. 
- how to include in-flight htlc risk?

any thoughts are appreciated! 