### PR TITLE
jam attack impl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 target
 data
 results
-reputation-snapshots
+reputation-snapshots*

--- a/ln-simln-jamming/src/attacks/mod.rs
+++ b/ln-simln-jamming/src/attacks/mod.rs
@@ -9,6 +9,7 @@ use triggered::Listener;
 use crate::{accountable_from_records, records_from_signal, BoxError, NetworkReputation};
 
 pub mod sink;
+pub mod slow_jam;
 pub mod utils;
 
 pub struct NetworkSetup {

--- a/ln-simln-jamming/src/attacks/slow_jam.rs
+++ b/ln-simln-jamming/src/attacks/slow_jam.rs
@@ -1,0 +1,278 @@
+use crate::{
+    attacks::JammingAttack,
+    clock::InstantClock,
+    reputation_interceptor::{GeneralChannelJammer, ReputationMonitor},
+    BoxError, NetworkReputation,
+};
+
+use async_trait::async_trait;
+use bitcoin::secp256k1::PublicKey;
+use lightning::{ln::PaymentHash, routing::gossip::NetworkGraph};
+use sim_cli::parsing::NetworkParser;
+use simln_lib::{
+    clock::Clock,
+    sim_node::{CustomRecords, ForwardingError, InterceptRequest, SimGraph, SimNode, WrappedLog},
+};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+    thread,
+    time::Duration,
+};
+use tokio::sync::Mutex;
+use triggered::Listener;
+
+use super::utils::{build_custom_route, build_reputation, get_random_bytes};
+
+// idea: attacker1 -> peer1 -> target -> attacker2
+// build reputation on attacker2 and jam channel peer1 <-> target
+
+type LdkNetworkGraph = NetworkGraph<Arc<WrappedLog>>;
+
+pub struct SlowJam<C, J, R>
+where
+    C: Clock + InstantClock,
+    R: ReputationMonitor + Send + Sync,
+    J: GeneralChannelJammer + Send + Sync,
+{
+    clock: Arc<C>,
+    target_pubkey: PublicKey,
+    attacker_sender: (String, PublicKey),
+    attacker: (String, PublicKey),
+    target_channels: HashMap<u64, PublicKey>,
+    channel_to_jam: (PublicKey, u64),
+    risk_margin: u64,
+    reputation_monitor: Arc<Mutex<R>>,
+    general_jammer: Arc<Mutex<J>>,
+    network_graph: Arc<LdkNetworkGraph>,
+    jamming_payments: Mutex<HashSet<PaymentHash>>,
+}
+
+impl<C, J, R> SlowJam<C, J, R>
+where
+    C: Clock + InstantClock,
+    R: ReputationMonitor + Send + Sync,
+    J: GeneralChannelJammer + Send + Sync,
+{
+    pub fn new(
+        clock: Arc<C>,
+        network: &[NetworkParser],
+        target_pubkey: PublicKey,
+        attacker_sender: (String, PublicKey),
+        attacker: (String, PublicKey),
+        channel_to_jam: (PublicKey, u64),
+        risk_margin: u64,
+        reputation_monitor: Arc<Mutex<R>>,
+        general_jammer: Arc<Mutex<J>>,
+        network_graph: Arc<LdkNetworkGraph>,
+    ) -> Self {
+        Self {
+            clock,
+            target_pubkey,
+            attacker_sender,
+            attacker,
+            target_channels: HashMap::from_iter(network.iter().filter_map(|channel| {
+                if channel.node_1.pubkey == target_pubkey {
+                    Some((channel.scid.into(), channel.node_2.pubkey))
+                } else if channel.node_2.pubkey == target_pubkey {
+                    Some((channel.scid.into(), channel.node_1.pubkey))
+                } else {
+                    None
+                }
+            })),
+            channel_to_jam,
+            risk_margin,
+            reputation_monitor,
+            general_jammer,
+            network_graph,
+            jamming_payments: Mutex::new(HashSet::new()),
+        }
+    }
+
+    pub async fn build_reputation(
+        &self,
+        attacker_nodes: &HashMap<String, Arc<Mutex<SimNode<SimGraph>>>>,
+    ) -> Result<u64, BoxError> {
+        let hops = vec![self.target_pubkey, self.attacker.1];
+        // let target_channel = self.channel_to_jam;
+        let target_channel = (self.target_pubkey, self.channel_to_jam.1);
+
+        let attacker_node_sender = attacker_nodes.get(&self.attacker_sender.0).ok_or(format!(
+            "node {} not found in attacker nodes list",
+            self.attacker_sender.0
+        ))?;
+
+        let fees_paid = build_reputation(
+            Arc::clone(attacker_node_sender),
+            &hops,
+            &self.network_graph,
+            vec![30_000_000],
+            self.risk_margin,
+            target_channel,
+            Arc::clone(&self.reputation_monitor),
+            Arc::clone(&self.clock),
+        )
+        .await?;
+
+        if self.sufficient_reputation().await? {
+            return Ok(fees_paid);
+        } else {
+            Err("could not build reputation".into())
+        }
+    }
+
+    // Checks if the attacker has sufficient reputation on its channel with the target node to keep
+    // jamming it
+    async fn sufficient_reputation(&self) -> Result<bool, BoxError> {
+        let to_attacker_channel = self
+            .target_channels
+            .iter()
+            .find(|chan| self.attacker.1 == *chan.1)
+            .ok_or(format!(
+                "Target does not have a channel with {}",
+                self.attacker.1
+            ))?
+            .0;
+
+        let target_channel_snapshots = self
+            .reputation_monitor
+            .lock()
+            .await
+            .list_channels(self.target_pubkey, InstantClock::now(&*self.clock))
+            .await?;
+
+        let to_attacker_channel_snapshot = target_channel_snapshots
+            .get(to_attacker_channel)
+            .ok_or(format!("Channel {} not found", to_attacker_channel))?; // this shouldn't happen
+
+        let peer_target_channel = target_channel_snapshots
+            .get(&self.channel_to_jam.1)
+            .ok_or(format!("Channel {} not found", self.channel_to_jam.1))?;
+
+        let sufficient_reputation = to_attacker_channel_snapshot.outgoing_reputation
+            >= peer_target_channel.bidirectional_revenue + self.risk_margin as i64;
+
+        return Ok(sufficient_reputation);
+    }
+
+    async fn fast_jam_channel(
+        &self,
+        attacker_nodes: HashMap<String, Arc<Mutex<SimNode<SimGraph>>>>,
+        channel_to_jam: (PublicKey, u64),
+    ) -> Result<(), BoxError> {
+        // at this point, we should already have built reputation and have access to protected
+        // resources. Attack channel peer1 <-> target through attacker1 -> peer1 -> target -> attacker2
+
+        let attacker_node_sender = attacker_nodes.get(&self.attacker_sender.0).ok_or(format!(
+            "node {} not found in attacker nodes list",
+            self.attacker_sender.0
+        ))?;
+
+        // Jam resources with low-value htlcs to occupy as many slots as possible while trying not
+        // to affect reputation negatively?
+        let hops = vec![channel_to_jam.0, self.target_pubkey, self.attacker.1];
+        let route = build_custom_route(&self.attacker_sender.1, 1_000, &hops, &self.network_graph)
+            .map_err(|e| e.err)?;
+
+        loop {
+            let payment_hash = PaymentHash(get_random_bytes());
+            if let Err(e) = attacker_node_sender
+                .lock()
+                .await
+                .send_to_route(route.clone(), payment_hash, None)
+                .await
+            {
+                return Err(e.to_string().into());
+            }
+            self.jamming_payments.lock().await.insert(payment_hash);
+
+            thread::sleep(Duration::from_millis(200));
+
+            // do this until no more reputation
+            if !self.sufficient_reputation().await? {
+                break;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl<C, J, R> JammingAttack for SlowJam<C, J, R>
+where
+    C: Clock + InstantClock,
+    R: ReputationMonitor + Send + Sync,
+    J: GeneralChannelJammer + Send + Sync,
+{
+    /// Payments where we are the receiver are most likely the ones initiated by us from [`Self::fast_jam_channel`]. Fast-jamming
+    /// here so fail them immediately while trying to continuously take up protected resources on
+    /// the channel we are trying to jam.
+    async fn intercept_attacker_receive(
+        &self,
+        req: InterceptRequest,
+    ) -> Result<Result<CustomRecords, ForwardingError>, BoxError> {
+        let mut jamming_payments_lock = self.jamming_payments.lock().await;
+        // If this is not a jamming payment (generated from fast_jam_channel) then let it go
+        // through since it must be one where we are trying to build reputation.
+        if !jamming_payments_lock.contains(&req.payment_hash) {
+            Ok(Ok(req.incoming_custom_records))
+        } else {
+            // If we are trying to fast jam the channel, fail the payment immediately.
+            jamming_payments_lock.remove(&req.payment_hash);
+            Ok(Err(ForwardingError::InterceptorError(
+                "failing from jamming interceptor".into(),
+            )))
+        }
+    }
+
+    async fn run_custom_actions(
+        &self,
+        attacker_nodes: HashMap<String, Arc<Mutex<SimNode<SimGraph>>>>,
+        _shutdown_listener: Listener,
+    ) -> Result<(), BoxError> {
+        // - Build reputation with helper
+        // - after building reputation, jam general resources.
+        // - use congestion
+        // - with sufficient reputation, continuously jam protected resources by sending slow (80s)
+        //  resolving payments that don't slash reputation.
+
+        let fees_paid = self.build_reputation(&attacker_nodes).await?;
+        println!(
+            "Finished building reputation. It cost {} in fees",
+            fees_paid
+        );
+
+        // after building reputation, jam general resources.
+        self.general_jammer
+            .lock()
+            .await
+            .jam_channel(&self.target_pubkey, self.channel_to_jam.1)
+            .await?;
+
+        // TODO: to jam congestion, would need many channels where each will occupy one slot in
+        // congestion bucket until full.
+
+        // after building reputation and jamming general resources, jam protected resources with
+        // continuous fast-failing payments.
+        // NOTE: prob better to occupy protected slots with low-value htlcs.
+        self.fast_jam_channel(attacker_nodes, self.channel_to_jam)
+            .await?;
+
+        Ok(())
+    }
+
+    async fn simulation_completed(
+        &self,
+        _start_reputation: NetworkReputation,
+    ) -> Result<bool, BoxError> {
+        // If attacker has no more reputation with the target, end simulation.
+        if !self.sufficient_reputation().await? {
+            return Ok(true);
+        }
+
+        // TODO: shutdown conditions for revenue.
+
+        Ok(false)
+    }
+}

--- a/ln-simln-jamming/src/attacks/utils.rs
+++ b/ln-simln-jamming/src/attacks/utils.rs
@@ -1,18 +1,28 @@
+use std::{sync::Arc, thread, time::Duration};
+
 use bitcoin::secp256k1::PublicKey;
 use lightning::{
-    ln::msgs::LightningError,
+    ln::{msgs::LightningError, PaymentHash},
     routing::{
         gossip::NetworkGraph,
         router::{build_route_from_hops, PaymentParameters, Route, RouteParameters},
     },
 };
-use simln_lib::sim_node::WrappedLog;
+use rand::Rng;
+use simln_lib::{
+    clock::Clock,
+    sim_node::{SimGraph, SimNode, WrappedLog},
+    LightningNode,
+};
+use tokio::sync::Mutex;
+
+use crate::{clock::InstantClock, reputation_interceptor::ReputationMonitor, BoxError};
 
 pub fn build_custom_route(
     sender: &PublicKey,
     amount_msat: u64,
     hops: &[PublicKey],
-    network_graph: &NetworkGraph<&WrappedLog>,
+    network_graph: &NetworkGraph<Arc<WrappedLog>>,
 ) -> Result<Route, LightningError> {
     let route_params = &RouteParameters {
         payment_params: PaymentParameters::from_node_id(hops[hops.len() - 1], 0)
@@ -31,4 +41,133 @@ pub fn build_custom_route(
         &WrappedLog {},
         &[0; 32],
     )
+}
+
+/// Helper to build reputation for a specific incoming channel (target_channel).
+/// Arguments:
+/// - `hops`: The route for the payment that should include the outgoing channel for which we are
+/// building reputation with (do not include sender).
+/// - htlcs: Vector of htlc amounts that we'd want to be able to have in the protected bucket. E.g
+/// if [100_000] is passed, it will build enough reputation to have a 100_000 htlc in the protected
+/// bucket for the target channel.
+/// - target_channel: The public key and scid for the target channel that we are building
+/// reputation for.
+///
+/// Example: `hops` could be the following route:
+/// - A → B → C
+///
+/// The channel B <-> C is the outgoing channel that is building reputation.
+/// The `target_channel` is channel for which reputation is being built. So we will monitor the
+/// outgoing channel reputation (B <-> C) against the target_channel revenue.
+/// If successful, it returns the total fees paid to build reputation.
+#[allow(clippy::too_many_arguments)]
+pub async fn build_reputation<C: Clock + InstantClock, R: ReputationMonitor>(
+    attacker_node: Arc<Mutex<SimNode<SimGraph>>>,
+    hops: &[PublicKey],
+    network_graph: &NetworkGraph<Arc<WrappedLog>>,
+    htlcs: Vec<u64>,
+    risk_margin: u64,
+    target_channel: (PublicKey, u64),
+    reputation_monitor: Arc<Mutex<R>>,
+    clock: Arc<C>,
+) -> Result<u64, BoxError> {
+    let mut total_fees_paid = 0;
+
+    let mut attacker = attacker_node.lock().await;
+    let current_target_revenue = reputation_monitor
+        .lock()
+        .await
+        .list_channels(target_channel.0, InstantClock::now(&*clock))
+        .await?
+        .get(&target_channel.1)
+        .ok_or(format!("target channel {} not found", target_channel.1))?
+        .bidirectional_revenue;
+
+    let attacker_pubkey = attacker.get_info().pubkey;
+    let mut route =
+        build_custom_route(&attacker_pubkey, 1000, hops, network_graph).map_err(|e| e.err)?;
+
+    let last_hop_channel = route.paths[0]
+        .hops
+        .last()
+        .ok_or("built invalid route")?
+        .short_channel_id;
+
+    let current_attacker_reputation = reputation_monitor
+        .lock()
+        .await
+        .list_channels(target_channel.0, InstantClock::now(&*clock))
+        .await?
+        .get(&last_hop_channel)
+        .ok_or(format!("channel {} not found", last_hop_channel))?
+        .outgoing_reputation;
+
+    let htlc_amounts: u64 = htlcs.iter().sum();
+    for path in route.paths.iter_mut() {
+        total_fees_paid += path.hops.iter().map(|hop| hop.fee_msat).sum::<u64>();
+
+        let target_hop = match path
+            .hops
+            .iter_mut()
+            .find(|hop| hop.pubkey == target_channel.0)
+        {
+            Some(hop) => hop,
+            None => continue,
+        };
+
+        let threshold = if current_target_revenue - current_attacker_reputation > 0 {
+            current_target_revenue - current_attacker_reputation
+        } else {
+            0
+        };
+
+        let fee_to_bump_reputation = threshold as u64 + htlc_amounts + risk_margin;
+
+        // Make a single payment with an inflated fee at the hop we are building reputation with
+        target_hop.fee_msat += fee_to_bump_reputation;
+        total_fees_paid += fee_to_bump_reputation;
+    }
+
+    let payment_hash = PaymentHash(get_random_bytes());
+    if let Err(e) = attacker
+        .send_to_route(route.clone(), payment_hash, None)
+        .await
+    {
+        return Err(e.to_string().into());
+    }
+
+    thread::sleep(Duration::from_millis(400));
+
+    // After making the payment with the inflated fee, check if reputation built over outgoing
+    // channel is sufficient.
+    let target_revenue = reputation_monitor
+        .lock()
+        .await
+        .list_channels(target_channel.0, InstantClock::now(&*clock))
+        .await?
+        .get(&target_channel.1)
+        .ok_or(format!("channel {} not found", target_channel.1))?
+        .bidirectional_revenue;
+
+    let attacker_reputation = reputation_monitor
+        .lock()
+        .await
+        .list_channels(target_channel.0, InstantClock::now(&*clock))
+        .await?
+        .get(&last_hop_channel)
+        .unwrap()
+        .outgoing_reputation;
+
+    if attacker_reputation as u64 > (target_revenue as u64 + htlc_amounts + risk_margin) {
+        Ok(total_fees_paid)
+    } else {
+        Err("could not build reputation".into())
+    }
+}
+
+pub fn get_random_bytes() -> [u8; 32] {
+    let mut rng = rand::rng();
+    let mut bytes = [0u8; 32];
+    rng.fill(&mut bytes[..]);
+    bytes
 }

--- a/ln-simln-jamming/src/attacks/utils.rs
+++ b/ln-simln-jamming/src/attacks/utils.rs
@@ -105,7 +105,6 @@ pub async fn build_reputation<C: Clock + InstantClock, R: ReputationMonitor>(
     let htlc_amounts: u64 = htlcs.iter().sum();
     for path in route.paths.iter_mut() {
         total_fees_paid += path.hops.iter().map(|hop| hop.fee_msat).sum::<u64>();
-
         let target_hop = match path
             .hops
             .iter_mut()
@@ -121,7 +120,7 @@ pub async fn build_reputation<C: Clock + InstantClock, R: ReputationMonitor>(
             0
         };
 
-        let fee_to_bump_reputation = threshold as u64 + htlc_amounts + risk_margin;
+        let fee_to_bump_reputation = threshold as u64 + htlc_amounts + risk_margin * 2;
 
         // Make a single payment with an inflated fee at the hop we are building reputation with
         target_hop.fee_msat += fee_to_bump_reputation;

--- a/ln-simln-jamming/src/main.rs
+++ b/ln-simln-jamming/src/main.rs
@@ -1,9 +1,10 @@
 use bitcoin::secp256k1::PublicKey;
 use clap::Parser;
 use core::panic;
+use lightning::routing::gossip::NetworkGraph;
 use ln_simln_jamming::analysis::BatchForwardWriter;
 use ln_simln_jamming::attack_interceptor::AttackInterceptor;
-use ln_simln_jamming::attacks::sink::SinkAttack;
+use ln_simln_jamming::attacks::slow_jam::SlowJam;
 use ln_simln_jamming::attacks::JammingAttack;
 use ln_simln_jamming::clock::InstantClock;
 use ln_simln_jamming::parsing::{
@@ -16,17 +17,21 @@ use ln_simln_jamming::{
     get_network_reputation, BoxError, NetworkReputation, ACCOUNTABLE_TYPE, UPGRADABLE_TYPE,
 };
 use log::LevelFilter;
-use sim_cli::parsing::{create_simulation_with_network, SimParams};
+use sim_cli::parsing::{create_simulation_with_network, NetworkParser, SimParams};
 use simln_lib::clock::Clock;
 use simln_lib::clock::SimulationClock;
 use simln_lib::latency_interceptor::LatencyIntercepor;
-use simln_lib::sim_node::{CustomRecords, Interceptor, SimGraph, SimNode};
-use simln_lib::SimulationCfg;
+use simln_lib::sim_node::{
+    populate_network_graph, CustomRecords, Interceptor, SimGraph, SimNode, SimulatedChannel,
+    WrappedLog,
+};
+use simln_lib::{SimulationCfg, SimulationError};
 use simple_logger::SimpleLogger;
 use std::collections::HashMap;
 use std::fs::{self, OpenOptions};
 use std::io::{BufWriter, Write};
 use std::path::PathBuf;
+use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::select;
@@ -142,14 +147,38 @@ async fn main() -> Result<(), BoxError> {
     );
 
     // Next, setup the attack interceptor to use our custom attack.
-    let attack = Arc::new(SinkAttack::new(
-        clock.clone(),
+    // let attack = Arc::new(SinkAttack::new(
+    //     clock.clone(),
+    //     &sim_network,
+    //     target_pubkey,
+    //     attacker_pubkey,
+    //     risk_margin,
+    //     reputation_interceptor.clone(),
+    //     listener.clone(),
+    // ));
+
+    let attacker_sender_pubkey =
+        PublicKey::from_str("033dbb3f4662640d4888918eeb986069b9b775c921b9ec6debcada1b3ac58a1b0b")
+            .unwrap();
+    let attacker_sender = ("25".to_string(), attacker_sender_pubkey);
+
+    let target_peer_pubkey =
+        PublicKey::from_str("03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f")
+            .unwrap();
+    let channel_to_jam = (target_peer_pubkey, 348545186070528);
+
+    let network_graph = network_graph(sim_network.clone())?;
+    let attack = Arc::new(SlowJam::new(
+        Arc::clone(&clock),
         &sim_network,
         target_pubkey,
-        attacker_pubkey,
+        attacker_sender,
+        (cli.attacker_alias.clone(), attacker_pubkey),
+        channel_to_jam,
         risk_margin,
-        reputation_interceptor.clone(),
-        listener.clone(),
+        Arc::clone(&reputation_interceptor),
+        Arc::clone(&reputation_interceptor),
+        network_graph,
     ));
 
     let attack_setup = attack.setup_for_network()?;
@@ -161,27 +190,6 @@ async fn main() -> Result<(), BoxError> {
             .await?;
     }
 
-    let attack_custom_actions = Arc::clone(&attack);
-
-    // Do some preliminary checks on our reputation state - there isn't much point in running if we haven't built up
-    // some reputation.
-    let target_pubkey_map: HashMap<u64, PublicKey> =
-        target_channels.iter().map(|(k, v)| (*k, v.0)).collect();
-
-    let start_reputation = get_network_reputation(
-        reputation_interceptor.clone(),
-        target_pubkey,
-        attacker_pubkey,
-        &target_pubkey_map,
-        risk_margin,
-        // The reputation_interceptor clock has been set on decaying averages so we use the clock
-        // to provide a new instant rather than the previous fixed point.
-        InstantClock::now(&*clock),
-    )
-    .await?;
-
-    check_reputation_status(&cli, &start_reputation)?;
-
     let attack_interceptor = AttackInterceptor::new(
         attacker_pubkey,
         reputation_interceptor.clone(),
@@ -190,38 +198,13 @@ async fn main() -> Result<(), BoxError> {
 
     let attack_interceptor = Arc::new(attack_interceptor);
 
-    // Spawn a task that will trigger shutdown of the simulation if the attacker loses reputation provided that the
-    // target is at similar reputation to the start of the simulation. This is a somewhat crude check, because we're
-    // only looking at the count of peers with reputation not the actual pairs.
-    let attack_clock = clock.clone();
-    let attack_listener = listener.clone();
-    let attack_shutdown = shutdown.clone();
-    let start_reputation_1 = start_reputation.clone();
-    tasks.spawn(async move {
-        let interval = Duration::from_secs(cli.attacker_poll_interval_seconds);
-        loop {
-            select! {
-                _ = attack_listener.clone() => return,
-                _ = attack_clock.sleep(interval) => {
-                    match attack.simulation_completed(start_reputation_1.clone()).await {
-                        Ok(shutdown) => if shutdown {attack_shutdown.trigger()},
-                        Err(e) => {
-                            log::error!("Shutdown check failed: {e}");
-                            attack_shutdown.trigger();
-                        },
-                    }
-                }
-            }
-        }
-    });
-
     let revenue_interceptor = Arc::new(
         RevenueInterceptor::new_with_bootstrap(
             clock.clone(),
             target_pubkey,
             bootstrap_revenue,
             cli.attacker_bootstrap.1,
-            cli.peacetime_file,
+            cli.peacetime_file.clone(),
             listener.clone(),
             shutdown.clone(),
         )
@@ -280,7 +263,7 @@ async fn main() -> Result<(), BoxError> {
     let attacker_nodes: HashMap<String, Arc<Mutex<SimNode<SimGraph>>>> = sim_nodes
         .into_iter()
         .filter_map(|(pk, node)| {
-            if pk == attacker_pubkey {
+            if pk == attacker_pubkey || pk == attacker_sender_pubkey {
                 let alias = match find_alias_by_pubkey(&pk, &sim_params.sim_network) {
                     Ok(alias) => alias,
                     Err(e) => panic!("Attacker pubkey not found {}", e),
@@ -294,6 +277,55 @@ async fn main() -> Result<(), BoxError> {
         .collect();
 
     let attacker_actions_shutdown = shutdown.clone();
+    attack.build_reputation(&attacker_nodes).await?;
+
+    // Do some preliminary checks on our reputation state - there isn't much point in running if we haven't built up
+    // some reputation.
+    let target_pubkey_map: HashMap<u64, PublicKey> =
+        target_channels.iter().map(|(k, v)| (*k, v.0)).collect();
+
+    let start_reputation = get_network_reputation(
+        reputation_interceptor.clone(),
+        target_pubkey,
+        attacker_pubkey,
+        &target_pubkey_map,
+        risk_margin,
+        // The reputation_interceptor clock has been set on decaying averages so we use the clock
+        // to provide a new instant rather than the previous fixed point.
+        InstantClock::now(&*clock),
+    )
+    .await?;
+
+    check_reputation_status(&cli, &start_reputation)?;
+
+    // Spawn a task that will trigger shutdown of the simulation if the attacker loses reputation provided that the
+    // target is at similar reputation to the start of the simulation. This is a somewhat crude check, because we're
+    // only looking at the count of peers with reputation not the actual pairs.
+    let attack_clock = clock.clone();
+    let attack_listener = listener.clone();
+    let attack_shutdown = shutdown.clone();
+    let start_reputation_1 = start_reputation.clone();
+    let tasks = TaskTracker::new();
+    let attack_clone = Arc::clone(&attack);
+    tasks.spawn(async move {
+        let interval = Duration::from_secs(cli.attacker_poll_interval_seconds);
+        loop {
+            select! {
+                _ = attack_listener.clone() => return,
+                _ = attack_clock.sleep(interval) => {
+                    match attack_clone.simulation_completed(start_reputation_1.clone()).await {
+                        Ok(shutdown) => if shutdown {attack_shutdown.trigger()},
+                        Err(e) => {
+                            log::error!("Shutdown check failed: {e}");
+                            attack_shutdown.trigger();
+                        },
+                    }
+                }
+            }
+        }
+    });
+
+    let attack_custom_actions = Arc::clone(&attack);
     tokio::spawn(async move {
         if let Err(e) = attack_custom_actions
             .run_custom_actions(attacker_nodes, listener.clone())
@@ -364,6 +396,22 @@ fn check_reputation_status(cli: &Cli, status: &NetworkReputation) -> Result<(), 
     }
 
     Ok(())
+}
+
+fn network_graph(
+    network: Vec<NetworkParser>,
+) -> Result<Arc<NetworkGraph<Arc<WrappedLog>>>, BoxError> {
+    let channels = network
+        .clone()
+        .into_iter()
+        .map(SimulatedChannel::from)
+        .collect::<Vec<SimulatedChannel>>();
+
+    let clock = Arc::new(SimulationClock::new(1)?);
+    Ok(Arc::new(
+        populate_network_graph(channels, clock.clone())
+            .map_err(|e| SimulationError::SimulatedNetworkError(format!("{:?}", e)))?,
+    ))
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/ln-simln-jamming/src/parsing.rs
+++ b/ln-simln-jamming/src/parsing.rs
@@ -160,7 +160,8 @@ pub struct Cli {
 
 impl Cli {
     pub fn validate(&self) -> Result<ForwardManagerParams, BoxError> {
-        if self.target_reputation_percent == 0 || self.target_reputation_percent > 100 {
+        //if self.target_reputation_percent == 0 || self.target_reputation_percent > 100 {
+        if self.target_reputation_percent > 100 {
             return Err(format!(
                 "target reputation percent {} must be in (0;100]",
                 self.target_reputation_percent


### PR DESCRIPTION
Hopefully a not so lame attempt at implementing an attack, tried doing one from the delving post. 

There are a couple things hardcoded and I added a couple extra channels to the base graph. 

Attack: jam and use all resources for a channel between [target_node_peer] <-> [target_node] by building reputation with attacker node. 

Using an attacker sender node (A1) and a attacker receiver (A2), will try to jam channel for:
A1 -> [target_peer] -> [target] -> A2 

- First use `build_reputation` helper to build reputation over A1 -> [target] -> A2 against the channel with the target peer.
- jam general resources.
- TODO: would need many channels to occupy slots in congestion (?)
- with sufficient reputation and general resources jammed, jam protected resources with continuous fast-failing payments that don't slash reputation. 

Need to define shutdown conditions. 

Other things for https://github.com/carlaKC/jam-ln/issues/72 to make it friendlier to write attacks:
- ability to define multiple attackers (and need to know how you will use them ?). I just hardcoded one of them.
- as mentioned here: https://github.com/carlaKC/jam-ln/issues/71 prob make an enum-like type to specify multiple attacks that the simulation could be run with. Although indeed ugly with `dyn` trait. Or could make a wrapper struct that impls `JammingAttack`. 
- there are some discrepancies with the default filenames used so they need manual modifying but I think they will be fixed in https://github.com/carlaKC/jam-ln/issues/84. 