### PR TITLE
Allow Running without Attacker Bootstrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 *.json
 *.csv
+*.txt
 target
 data
-results
-reputation-snapshots
+results/*

--- a/README.md
+++ b/README.md
@@ -1,73 +1,102 @@
 # Jamming Simulator
 
-This simulator implements [outgoing reputation](https://gist.github.com/carlaKC/6762d88903d1cc27339859816ed80d43)
-for a network of nodes and performs a [sink attack](https://delvingbitcoin.org/t/hybrid-jamming-mitigation-results-and-updates/1147#p-3212-manipulation-sink-attack-9)
-against a target node in the network. In this attack, a malicious node
-will:
-- Open up channels and forward payments as usual to bootstrap its
-  reputation with a target node.
-- Slow jam the target's peers's general resources, so that all HTLCs
-  must be accountable to reach the target.
-- Hold any accountable HTLCs from the target with the goal of ruining its
-  reputation with its peers.
+This simulator implements the following to mitigate channel jamming
+attacks:
+- Outgoing reputation:
+  When forwarding a HTLC, the reputation of the *outgoing* channel is
+  compared to the revenue that's been earned on the *incoming* channel.
+- HTLC accountability: if a HTLC has occupied scarce resources, it
+  will be forwarded as accountable to indicate to the receiving node
+  that their reputation will be held accountable for its resolution.
+- Resource bucketing: resources are divided into buckets
+  - General: available to all channels, with some restrictions on how many
+    resources a single peer can occupy.
+  - Congestion: used when general resources are saturated, with strict
+    control on access (because the node is likely under attack if general
+    is full).
+  - Protected: available to nodes with sufficient reputation.
 
-## Requirements
+A draft writeup of this scheme is available [here](https://github.com/carlaKC/lightning-rfc/pull/5).
+The evolution of how we've been thinking about this problem is 
+summarized [here](https://gist.github.com/carlaKC/5139adf4fd12b4ecd53c660b5be11bf0).
 
-To run the simulation you will need:
-- `sim_file.json`: a json file describing the network that is being simulated,
-  including channels that the attacking node has created to draw in 
-  traffic. An example is available [here](https://github.com/carlaKC/attackathon/blob/master/data/ln_51_attacker/simln.json).
-- `bootstrap.csv`: a csv containing projected forwards for the network
-  *including*  that attacker's channels.
-- `peacetime.csv`: a csv containing projected forwards for the network
-  *excluding* the attacker's channels.
-
-Projections are generated using [a sim-ln branch](https://github.com/carlaKC/sim-ln/tree/interceptor-latency)
-that runs on a fully simulated network and outputs forwarding records
-for each node in the network.
-
-To run the simulator with the above files in the current directory:
-```
-make install
-ln-simln-jamming --target-alias {alias string} --attacker-alias {alias string}
-```
-
-There are various ways that the simulator can be customized, see 
-`cargo run -- --help` for details. A script is also provided to run
-a set of simulations with different attacker bootstrap values in 
-`./run_simulations.sh`.
-
-## Attack Implementation
-
-On startup, the simulator will use the `bootstrap-file` to set up 
-reputation scores for the network:
-- Honest nodes will have payments replayed for the full `reputation_window`
-  that the simulator is configured with (default: 6 months, equal to
-  `revenue-window-seconds reputation-multiplier`).
-- The attacking node will have payments replayed for the 
-  `attacker-bootstrap`, which must be <= `reputation_window`.
-
-This sets up a starting point where the attacker has been peacefully
-forwarding payments for the bootstrap period provided, and all honest
-channels in the network have been around for at least the 
-`reputation_window`.
-
-The simulation will then start, implementing the attack as follows:
-- General jamming the target's peers, so that only accountable HTLCs
-  reach the target node.
-- The attacking node will hold HTLCs for the maximum allowable period
-  before risking a force close, then fail them back.
-
-To compare revenue under attack, the forwards in the `peacetime.csv`
-projection will be replayed as the simulation executes.
-
-The simulation will shut down if:
-- The target node's revenue in the simulation dips below its projected
-  peacetime revenue (it has suffered revenue loss).
-- The attacker no longer has reputation with the target (it can't
-  continue its attack).
+The simulator will execute a channel jamming attack against a target
+node running the above proposed mitigation. It will exit when:
+- The target's projected revenue in times of peace is less than its
+  revenue under attack (in the simulation)
+- The attack-specific shutdown condition has been met.
 - The simulator has run out of peacetime forward to replay to compare
   revenue.
+
+## Install
+
+To install and run the simulator:
+```
+make install
+ln-simln-jamming --network-dir {path to network directory}
+```
+
+## Tooling
+
+To help set up custom networks for this simulator, the following tooling
+is available:
+* `forward-builder`: simulates payment traffic on a graph and records
+  each node's forwarded HTLCs. This output is used to generate starting
+  state reputation for all the nodes in the network, and to project
+  what the target's revenue would be in times of peace (when not under
+  attack).
+* `reputation-builder`: creates a summary of each node in the network's
+  starting reputation state, based on the output provided from
+  `forward-builder`. Used to speed up simulation start times.
+
+To install:
+```
+make install-tools
+```
+
+## Network Directory
+
+To run the simulation, the following files are required in the directory
+specified by the `--network` option:
+* `peacetime_network.json`: the lightning network [graph](https://github.com/carlaKC/sim-ln?tab=readme-ov-file#advanced-usage---network-simulation)
+  for the attack, with no attacker channels added.
+* `attacktime_network.json`: the lightning network [graph](https://github.com/carlaKC/sim-ln?tab=readme-ov-file#advanced-usage---network-simulation)
+  for the attack, with attacker channels added.
+* `peacetime_traffic.csv`: a projected set of forwards for the 
+  `peacetime_network.json` file, used to determine what the target's
+  revenue would be in times of peace.
+* `target.txt`: a text file containing the alias of the node being
+  targeted for attack.
+* `attacker.csv`: a csv file containing the alias of the attacking node.
+
+Note: At present the simulation only supports a single attacker and
+a single target node.
+
+### Starting Reputation State
+
+There are two options for setting up the starting reputation state for
+the simulator:
+1. Regular: start the simulator with reputations for honest nodes
+   bootstrapped for 6 months, and attacking channels starting with
+   no reputation.
+2. Attacker bootstrap: start the simulator with reputation for honest
+  nodes bootstrapped for 6 months, and attacking channels starting with
+  reputation earned from passively forwarding payments in the network
+  for a specified timestamp using `--attacker-bootstrap` 
+
+For each mode of operation, the simulator requires that a reputation
+summary is generated using the `reputation-builder` utility.
+For each mode, the simulator requires the following files:
+* `reputation_summary.csv`: a summary of each node's starting reputation
+  state.
+* `target_revenue.csv`: the target node's total revenue earned during
+  this bootstrap period, expressed in msat.
+
+These summaries may be generated using the `reputation-builder` utility.
+If generating summaries for the case where an attacker is bootstrapping
+their reputation passively, a `attacktime_traffic.csv` file will also
+be required in the `network` directory (which can be generated using
+the `forward-builder` utility)
 
 ## Shortcomings
 
@@ -76,7 +105,3 @@ The simulation will shut down if:
   our best guess at how payments flow in the network.
 - Payments are generated with a fixed seed, but this is not perfectly
   deterministic in sim-ln.
-- The simulator implements "just in time" upgradable accountability, bumping up
-  the accountability signal of a htlc only if it is required.
-- At present the simulator only expects one channel between the target
-  and attacking node.

--- a/ln-simln-jamming/src/bin/reputation_builder.rs
+++ b/ln-simln-jamming/src/bin/reputation_builder.rs
@@ -1,8 +1,7 @@
 use std::{
     collections::HashSet,
-    fs::{self, File, OpenOptions},
+    fs::{File, OpenOptions},
     io::Write,
-    path::PathBuf,
     sync::Arc,
     time::Duration,
 };
@@ -14,9 +13,8 @@ use ln_simln_jamming::{
     analysis::BatchForwardWriter,
     clock::InstantClock,
     parsing::{
-        find_pubkey_by_alias, get_history_for_bootstrap, history_from_file, parse_duration,
-        ReputationParams, SimNetwork, DEFAULT_REPUTATION_DIR, DEFAULT_REPUTATION_FILENAME,
-        DEFAULT_REVENUE_FILENAME, DEFAULT_SIM_FILE,
+        get_history_for_bootstrap, history_from_file, parse_duration, NetworkParams,
+        ReputationParams, SimulationFiles, TrafficType,
     },
     reputation_interceptor::{BootstrapRecords, ReputationInterceptor, ReputationMonitor},
     BoxError,
@@ -25,40 +23,17 @@ use log::LevelFilter;
 use simln_lib::clock::SimulationClock;
 use simple_logger::SimpleLogger;
 
-/// Default file used to bootstrap reputation.
-const DEFAULT_BOOTSTRAP_FILE: &str = "./bootstrap.csv";
-
 #[derive(Parser)]
 #[command(version, about)]
 struct Cli {
-    /// A json file describing the lightning channels being simulated.
-    #[arg(long, short, default_value = DEFAULT_SIM_FILE)]
-    sim_file: PathBuf,
+    #[command(flatten)]
+    network: NetworkParams,
 
-    /// A CSV file containing forwards for the network, including the attacker used to bootstrap reputation for the
-    /// simulation.
-    #[arg(long, default_value = DEFAULT_BOOTSTRAP_FILE)]
-    bootstrap_file: PathBuf,
-
-    /// The duration of time that reputation of the attacking node should be bootstrapped for, expressed as human
-    /// readable values (eg: 1w, 3d).
     #[arg(long, value_parser = parse_duration)]
-    attacker_bootstrap: Option<(String, Duration)>,
+    pub attacker_bootstrap: Option<Duration>,
 
     #[command(flatten)]
     pub reputation_params: ReputationParams,
-
-    /// The directory to write reputation snapshot and revenue file.
-    #[arg(long, default_value = DEFAULT_REPUTATION_DIR)]
-    results_dir: PathBuf,
-
-    /// The alias of the target node.
-    #[arg(long)]
-    target_alias: String,
-
-    /// The alias of the attacking node.
-    #[arg(long)]
-    attacker_alias: Option<String>,
 }
 
 #[tokio::main]
@@ -71,22 +46,23 @@ async fn main() -> Result<(), BoxError> {
 
     let cli = Cli::parse();
     let forward_params: ForwardManagerParams = cli.reputation_params.into();
-    let SimNetwork { sim_network } =
-        serde_json::from_str(&fs::read_to_string(cli.sim_file.as_path())?)?;
+
+    let network_type = match cli.attacker_bootstrap {
+        Some(_) => TrafficType::Attacktime,
+        None => TrafficType::Peacetime,
+    };
+    let network_dir = SimulationFiles::new(cli.network.network_dir, network_type)?;
+    let (attacker_pubkey, target_pubkey) = (network_dir.attacker.1, network_dir.target.1);
 
     let unfiltered_history = history_from_file(
-        &cli.bootstrap_file,
+        &network_dir.attacktime_traffic(),
         Some(forward_params.reputation_params.revenue_window),
     )
     .await?;
 
-    let target_pubkey = find_pubkey_by_alias(&cli.target_alias, &sim_network)?;
-
-    // filter bootstrap records if attacker alias and bootstrap provided
-    let bootstrap = if cli.attacker_alias.is_some() && cli.attacker_bootstrap.is_some() {
-        let attacker_pubkey = find_pubkey_by_alias(&cli.attacker_alias.unwrap(), &sim_network)?;
-
-        let target_to_attacker = match sim_network.iter().find(|&channel| {
+    // Filter bootstrap records if attacker alias and bootstrap provided.
+    let bootstrap = if let Some(bootstrap_dur) = cli.attacker_bootstrap {
+        let target_to_attacker = match network_dir.sim_network.iter().find(|&channel| {
             (channel.node_1.pubkey == target_pubkey && channel.node_2.pubkey == attacker_pubkey)
                 || (channel.node_1.pubkey == attacker_pubkey
                     && channel.node_2.pubkey == target_pubkey)
@@ -98,7 +74,7 @@ async fn main() -> Result<(), BoxError> {
         };
 
         get_history_for_bootstrap(
-            cli.attacker_bootstrap.clone().unwrap().1,
+            bootstrap_dur,
             unfiltered_history,
             HashSet::from_iter(vec![target_to_attacker]),
         )?
@@ -127,7 +103,7 @@ async fn main() -> Result<(), BoxError> {
     let mut reputation_interceptor: ReputationInterceptor<BatchForwardWriter, ForwardManager> =
         ReputationInterceptor::new_for_network(
             forward_params,
-            &sim_network,
+            &network_dir.sim_network,
             reputation_clock,
             None,
         )?;
@@ -137,26 +113,21 @@ async fn main() -> Result<(), BoxError> {
         .await?;
 
     let mut node_pubkeys = HashSet::new();
-    for chan in sim_network {
+    for chan in network_dir.sim_network.iter() {
         node_pubkeys.insert(chan.node_1.pubkey);
         node_pubkeys.insert(chan.node_2.pubkey);
     }
 
-    let snapshot_dir = match cli.attacker_bootstrap {
-        // if a bootstrap period is provided, write results in ./reputation-snapshot/{duration}
-        Some(bootstrap_filter) => cli.results_dir.join(bootstrap_filter.0),
-        None => cli.results_dir,
-    };
-    fs::create_dir_all(&snapshot_dir)?;
+    let (reputation_state, target_revenue) = network_dir.reputation_summary(cli.attacker_bootstrap);
 
-    let mut target_revenue = File::create(snapshot_dir.join(DEFAULT_REVENUE_FILENAME))?;
+    let mut target_revenue = File::create(target_revenue)?;
     write!(target_revenue, "{}", bootstrap_revenue)?;
 
     let snapshot_file = OpenOptions::new()
         .write(true)
         .truncate(true)
         .create(true)
-        .open(snapshot_dir.join(DEFAULT_REPUTATION_FILENAME))?;
+        .open(&reputation_state)?;
 
     let mut csv_writer = Writer::from_writer(snapshot_file);
     csv_writer.write_record([
@@ -184,7 +155,11 @@ async fn main() -> Result<(), BoxError> {
     }
     csv_writer.flush()?;
 
-    log::info!("Finished writing reputation snapshot to {:?}", snapshot_dir);
+    log::info!(
+        "Finished writing reputation snapshot to {:?} and {:?}",
+        reputation_state,
+        target_revenue
+    );
 
     Ok(())
 }

--- a/ln-simln-jamming/src/main.rs
+++ b/ln-simln-jamming/src/main.rs
@@ -6,10 +6,7 @@ use ln_simln_jamming::attack_interceptor::AttackInterceptor;
 use ln_simln_jamming::attacks::sink::SinkAttack;
 use ln_simln_jamming::attacks::JammingAttack;
 use ln_simln_jamming::clock::InstantClock;
-use ln_simln_jamming::parsing::{
-    find_alias_by_pubkey, find_pubkey_by_alias, reputation_snapshot_from_file, Cli, SimNetwork,
-    DEFAULT_REPUTATION_FILENAME, DEFAULT_REVENUE_FILENAME,
-};
+use ln_simln_jamming::parsing::{reputation_snapshot_from_file, Cli, SimulationFiles, TrafficType};
 use ln_simln_jamming::reputation_interceptor::{GeneralChannelJammer, ReputationInterceptor};
 use ln_simln_jamming::revenue_interceptor::{RevenueInterceptor, RevenueSnapshot};
 use ln_simln_jamming::{
@@ -24,7 +21,7 @@ use simln_lib::sim_node::{CustomRecords, Interceptor, SimGraph, SimNode};
 use simln_lib::SimulationCfg;
 use simple_logger::SimpleLogger;
 use std::collections::HashMap;
-use std::fs::{self, OpenOptions};
+use std::fs::OpenOptions;
 use std::io::{BufWriter, Write};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -48,18 +45,16 @@ async fn main() -> Result<(), BoxError> {
     let cli = Cli::parse();
     let forward_params = cli.validate()?;
 
-    let SimNetwork { sim_network } =
-        serde_json::from_str(&fs::read_to_string(cli.sim_file.as_path())?)?;
+    // We always want to load the attack time graph when running the simulation.
+    let network_dir =
+        SimulationFiles::new(cli.network.network_dir.clone(), TrafficType::Attacktime)?;
+    let (attacker_pubkey, target_pubkey) = (network_dir.attacker.1, network_dir.target.1);
 
     let tasks = TaskTracker::new();
     let (shutdown, listener) = triggered::trigger();
 
-    // Match the target alias using pubkeys provided in sim network file, then collect the pubkeys of all the
-    // non-attacker target peers.
-    let target_pubkey = find_pubkey_by_alias(&cli.target_alias, &sim_network)?;
-    let attacker_pubkey = find_pubkey_by_alias(&cli.attacker_alias, &sim_network)?;
-
-    let target_channels: HashMap<u64, (PublicKey, String)> = sim_network
+    let target_channels: HashMap<u64, (PublicKey, String)> = network_dir
+        .sim_network
         .iter()
         .filter_map(|channel| {
             if channel.node_1.pubkey == target_pubkey {
@@ -87,9 +82,10 @@ async fn main() -> Result<(), BoxError> {
     let now = InstantClock::now(&*clock);
 
     // Create a writer to store results for nodes that we care about.
+    let results_dir = network_dir.results_dir();
     let monitor_channels: Vec<(PublicKey, String)> = target_channels.values().cloned().collect();
     let results_writer = Arc::new(Mutex::new(BatchForwardWriter::new(
-        cli.results_dir.clone(),
+        results_dir.clone(),
         &monitor_channels,
         cli.result_batch_size,
         now,
@@ -115,17 +111,15 @@ async fn main() -> Result<(), BoxError> {
         }
     });
 
-    let reputation_dir = &cli.reputation_dir.join(cli.attacker_bootstrap.0.clone());
-    let reputation_snapshot =
-        reputation_snapshot_from_file(&reputation_dir.join(DEFAULT_REPUTATION_FILENAME))?;
-
-    let bootstrap_revenue: u64 =
-        std::fs::read_to_string(reputation_dir.join(DEFAULT_REVENUE_FILENAME))?.parse()?;
+    let (reputation_state, target_revenue) =
+        network_dir.reputation_summary(Some(cli.attacker_bootstrap));
+    let reputation_snapshot = reputation_snapshot_from_file(&reputation_state)?;
+    let bootstrap_revenue: u64 = std::fs::read_to_string(target_revenue)?.parse()?;
 
     let reputation_interceptor = Arc::new(Mutex::new(
         ReputationInterceptor::new_from_snapshot(
             forward_params,
-            &sim_network,
+            &network_dir.sim_network,
             reputation_snapshot,
             clock.clone(),
             Some(results_writer),
@@ -144,7 +138,7 @@ async fn main() -> Result<(), BoxError> {
     // Next, setup the attack interceptor to use our custom attack.
     let attack = Arc::new(SinkAttack::new(
         clock.clone(),
-        &sim_network,
+        &network_dir.sim_network,
         target_pubkey,
         attacker_pubkey,
         risk_margin,
@@ -220,8 +214,8 @@ async fn main() -> Result<(), BoxError> {
             clock.clone(),
             target_pubkey,
             bootstrap_revenue,
-            cli.attacker_bootstrap.1,
-            cli.peacetime_file,
+            cli.attacker_bootstrap,
+            network_dir.peacetime_traffic(),
             listener.clone(),
             shutdown.clone(),
         )
@@ -261,7 +255,7 @@ async fn main() -> Result<(), BoxError> {
     // Setup the simulated network with our fake graph.
     let sim_params = SimParams {
         nodes: vec![],
-        sim_network,
+        sim_network: network_dir.sim_network,
         activity: vec![],
         exclude: vec![attacker_pubkey, target_pubkey],
     };
@@ -277,16 +271,12 @@ async fn main() -> Result<(), BoxError> {
     )
     .await?;
 
+    let attacker_alias = network_dir.attacker.0;
     let attacker_nodes: HashMap<String, Arc<Mutex<SimNode<SimGraph>>>> = sim_nodes
         .into_iter()
         .filter_map(|(pk, node)| {
             if pk == attacker_pubkey {
-                let alias = match find_alias_by_pubkey(&pk, &sim_params.sim_network) {
-                    Ok(alias) => alias,
-                    Err(e) => panic!("Attacker pubkey not found {}", e),
-                };
-
-                Some((alias, node))
+                Some((attacker_alias.clone(), node))
             } else {
                 None
             }
@@ -310,8 +300,8 @@ async fn main() -> Result<(), BoxError> {
     // Write start and end state to a summary file.
     let end_reputation = get_network_reputation(
         reputation_interceptor,
-        target_pubkey,
-        attacker_pubkey,
+        network_dir.target.1,
+        network_dir.attacker.1,
         &target_pubkey_map,
         risk_margin,
         InstantClock::now(&*clock),
@@ -320,7 +310,7 @@ async fn main() -> Result<(), BoxError> {
 
     let snapshot = revenue_interceptor.get_revenue_difference().await;
     write_simulation_summary(
-        cli.results_dir,
+        results_dir,
         &snapshot,
         &start_reputation,
         &end_reputation,

--- a/ln-simln-jamming/src/main.rs
+++ b/ln-simln-jamming/src/main.rs
@@ -113,7 +113,12 @@ async fn main() -> Result<(), BoxError> {
 
     let (reputation_state, target_revenue) =
         network_dir.reputation_summary(Some(cli.attacker_bootstrap));
-    let reputation_snapshot = reputation_snapshot_from_file(&reputation_state)?;
+    let reputation_snapshot = reputation_snapshot_from_file(&reputation_state).map_err(|e| {
+        format!(
+            "could not find reputation snapshot {:?}, try generating one with reputation-builder: {:?}",
+            reputation_state, e
+        )
+    })?;
     let bootstrap_revenue: u64 = std::fs::read_to_string(target_revenue)?.parse()?;
 
     let reputation_interceptor = Arc::new(Mutex::new(

--- a/ln-simln-jamming/src/main.rs
+++ b/ln-simln-jamming/src/main.rs
@@ -20,7 +20,7 @@ use simln_lib::latency_interceptor::LatencyIntercepor;
 use simln_lib::sim_node::{CustomRecords, Interceptor, SimGraph, SimNode};
 use simln_lib::SimulationCfg;
 use simple_logger::SimpleLogger;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs::OpenOptions;
 use std::io::{BufWriter, Write};
 use std::path::PathBuf;
@@ -126,6 +126,7 @@ async fn main() -> Result<(), BoxError> {
             forward_params,
             &network_dir.sim_network,
             reputation_snapshot,
+            HashSet::new(),
             clock.clone(),
             Some(results_writer),
         )

--- a/ln-simln-jamming/src/parsing.rs
+++ b/ln-simln-jamming/src/parsing.rs
@@ -578,16 +578,16 @@ pub async fn peacetime_from_file(
             for result in csv_reader.records() {
                 let record: StringRecord = result?;
 
-                let forwarding_node = PublicKey::from_slice(&hex::decode(&record[8])?)?;
+                let forwarding_node = PublicKey::from_slice(&hex::decode(&record[6])?)?;
                 if forwarding_node != target_pubkey {
                     continue;
                 }
 
                 let incoming_amt: u64 = record[0].parse()?;
-                let outgoing_amt: u64 = record[4].parse()?;
+                let outgoing_amt: u64 = record[1].parse()?;
 
                 heap_clone.lock().unwrap().push(RevenueEvent {
-                    timestamp_ns: record[3].parse()?,
+                    timestamp_ns: record[5].parse()?,
                     fee_msat: incoming_amt - outgoing_amt,
                 })
             }

--- a/ln-simln-jamming/src/revenue_interceptor.rs
+++ b/ln-simln-jamming/src/revenue_interceptor.rs
@@ -93,7 +93,9 @@ impl PeacetimeRevenue {
         revenue_file: PathBuf,
         bootstrap_duration: Option<Duration>,
     ) -> Result<Self, BoxError> {
-        let mut peacetime_activity = peacetime_from_file(&revenue_file, target_pubkey).await?;
+        let mut peacetime_activity = peacetime_from_file(&revenue_file, target_pubkey)
+            .await
+            .map_err(|e| format!("could not read peacetime projections: {}", e))?;
 
         // Grab the first event to get our starting timestamp, push the event back on so that we can process it.
         let first_event = peacetime_activity

--- a/ln-simln-jamming/src/test_utils.rs
+++ b/ln-simln-jamming/src/test_utils.rs
@@ -2,6 +2,7 @@
 use std::time::Instant;
 
 use crate::reputation_interceptor::{BootstrapForward, ReputationMonitor};
+use crate::revenue_interceptor::PeacetimeRevenueMonitor;
 use crate::{records_from_signal, BoxError};
 use async_trait::async_trait;
 use bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey};
@@ -32,6 +33,15 @@ mock! {
     #[async_trait]
     impl ReputationMonitor for ReputationInterceptor{
         async fn list_channels(&self, node: PublicKey, access_ins: Instant) -> Result<HashMap<u64, ChannelSnapshot>, BoxError>;
+    }
+}
+
+mock! {
+    pub PeacetimeMonitor{}
+
+    #[async_trait]
+    impl PeacetimeRevenueMonitor for PeacetimeMonitor {
+        async fn get_revenue_difference(&self) -> crate::revenue_interceptor::RevenueSnapshot;
     }
 }
 


### PR DESCRIPTION
This PR introduces two key changes:
1. Network directory: enforce a fixed structure for the simulation files that we expect, so that end users can simply specify a `--network` option which will look for the files that we need.
2. No bootstrap: allow the simulation to run without any attacker bootstrap, only bootstrapping honest nodes and starting the attacker off with zero reputation.

Fixes #84 