### PR TITLE
Ability to specify more than one attacker

### DIFF
--- a/ln-simln-jamming/src/attacks/sink.rs
+++ b/ln-simln-jamming/src/attacks/sink.rs
@@ -55,16 +55,19 @@ impl<
         clock: Arc<C>,
         network: &[NetworkParser],
         target_pubkey: PublicKey,
-        attacker_pubkey: PublicKey,
+        attacker_pubkeys: Vec<PublicKey>,
         risk_margin: u64,
         reputation_monitor: Arc<Mutex<R>>,
         peacetime_revenue: Arc<M>,
         listener: Listener,
     ) -> Self {
+        // For sink attack we only use one attacker node.
+        assert!(attacker_pubkeys.len() == 1);
+
         Self {
             clock,
             target_pubkey,
-            attacker_pubkey,
+            attacker_pubkey: attacker_pubkeys[0],
             target_channels: HashMap::from_iter(network.iter().filter_map(|channel| {
                 if channel.node_1.pubkey == target_pubkey {
                     Some((
@@ -273,7 +276,7 @@ where
         let current_reputation = get_network_reputation(
             self.reputation_monitor.clone(),
             self.target_pubkey,
-            self.attacker_pubkey,
+            &[self.attacker_pubkey],
             &self
                 .target_channels
                 .iter()
@@ -320,7 +323,7 @@ mod tests {
             Arc::new(SimulationClock::new(1).unwrap()),
             network,
             target,
-            attacker,
+            vec![attacker],
             0,
             Arc::new(Mutex::new(MockReputationInterceptor::new())),
             Arc::new(MockPeacetimeMonitor::new()),

--- a/ln-simln-jamming/src/bin/forward_builder.rs
+++ b/ln-simln-jamming/src/bin/forward_builder.rs
@@ -58,7 +58,6 @@ async fn main() -> Result<(), BoxError> {
     let cli = Cli::parse();
 
     let network_dir = SimulationFiles::new(cli.network.network_dir.clone(), cli.traffic_type)?;
-    let (attacker_pubkey, target_pubkey) = (network_dir.attacker.1, network_dir.target.1);
 
     let clock = Arc::new(SimulationClock::new(500)?);
     let tasks = TaskTracker::new();
@@ -97,6 +96,11 @@ async fn main() -> Result<(), BoxError> {
         Some(13995354354227336701),
     );
 
+    let mut exclude_pubkeys = vec![network_dir.target.1];
+    for attacker in network_dir.attackers {
+        exclude_pubkeys.push(attacker.1);
+    }
+
     let custom_records =
         CustomRecords::from([(UPGRADABLE_TYPE, vec![1]), (ACCOUNTABLE_TYPE, vec![0])]);
 
@@ -104,7 +108,7 @@ async fn main() -> Result<(), BoxError> {
         nodes: vec![],
         sim_network: network_dir.sim_network,
         activity: vec![],
-        exclude: vec![attacker_pubkey, target_pubkey],
+        exclude: exclude_pubkeys,
     };
 
     let (simulation, validated_activities, _sim_nodes) = create_simulation_with_network(

--- a/ln-simln-jamming/src/main.rs
+++ b/ln-simln-jamming/src/main.rs
@@ -50,7 +50,7 @@ async fn main() -> Result<(), BoxError> {
     // We always want to load the attack time graph when running the simulation.
     let network_dir =
         SimulationFiles::new(cli.network.network_dir.clone(), TrafficType::Attacktime)?;
-    let (attacker_pubkey, target_pubkey) = (network_dir.attacker.1, network_dir.target.1);
+    let target_pubkey = network_dir.target.1;
 
     let tasks = TaskTracker::new();
     let (shutdown, listener) = triggered::trigger();
@@ -129,6 +129,7 @@ async fn main() -> Result<(), BoxError> {
     })?;
     let bootstrap_revenue: u64 = std::fs::read_to_string(target_revenue)?.parse()?;
 
+    let attacker_pubkeys: Vec<PublicKey> = network_dir.attackers.iter().map(|a| a.1).collect();
     let reputation_interceptor = Arc::new(Mutex::new(
         ReputationInterceptor::new_from_snapshot(
             forward_params,
@@ -139,7 +140,7 @@ async fn main() -> Result<(), BoxError> {
             if cli.attacker_bootstrap.is_some() {
                 HashSet::new()
             } else {
-                HashSet::from([network_dir.attacker.1])
+                HashSet::from_iter(attacker_pubkeys.clone())
             },
             clock.clone(),
             Some(results_writer),
@@ -182,7 +183,7 @@ async fn main() -> Result<(), BoxError> {
         clock.clone(),
         &network_dir.sim_network,
         target_pubkey,
-        attacker_pubkey,
+        attacker_pubkeys.clone(),
         risk_margin,
         reputation_interceptor.clone(),
         revenue_interceptor.clone(),
@@ -208,7 +209,7 @@ async fn main() -> Result<(), BoxError> {
     let start_reputation = get_network_reputation(
         reputation_interceptor.clone(),
         target_pubkey,
-        attacker_pubkey,
+        &attacker_pubkeys,
         &target_pubkey_map,
         risk_margin,
         // The reputation_interceptor clock has been set on decaying averages so we use the clock
@@ -220,7 +221,7 @@ async fn main() -> Result<(), BoxError> {
     check_reputation_status(&cli, &start_reputation)?;
 
     let attack_interceptor = AttackInterceptor::new(
-        attacker_pubkey,
+        attacker_pubkeys.clone(),
         reputation_interceptor.clone(),
         attack.clone(),
     );
@@ -261,12 +262,15 @@ async fn main() -> Result<(), BoxError> {
     let custom_records =
         CustomRecords::from([(UPGRADABLE_TYPE, vec![1]), (ACCOUNTABLE_TYPE, vec![0])]);
 
+    let mut exclude = attacker_pubkeys.clone();
+    exclude.push(target_pubkey);
+
     // Setup the simulated network with our fake graph.
     let sim_params = SimParams {
         nodes: vec![],
         sim_network: network_dir.sim_network,
         activity: vec![],
-        exclude: vec![attacker_pubkey, target_pubkey],
+        exclude,
     };
 
     let sim_cfg = SimulationCfg::new(None, 3_800_000, 2.0, None, Some(13995354354227336701));
@@ -280,15 +284,14 @@ async fn main() -> Result<(), BoxError> {
     )
     .await?;
 
-    let attacker_alias = network_dir.attacker.0;
     let attacker_nodes: HashMap<String, Arc<Mutex<SimNode<SimGraph>>>> = sim_nodes
         .into_iter()
         .filter_map(|(pk, node)| {
-            if pk == attacker_pubkey {
-                Some((attacker_alias.clone(), node))
-            } else {
-                None
-            }
+            network_dir
+                .attackers
+                .iter()
+                .find(|attacker| attacker.1 == pk)
+                .map(|a| (a.0.clone(), node))
         })
         .collect();
 
@@ -317,7 +320,7 @@ async fn main() -> Result<(), BoxError> {
     let end_reputation = get_network_reputation(
         reputation_interceptor,
         network_dir.target.1,
-        network_dir.attacker.1,
+        &attacker_pubkeys,
         &target_pubkey_map,
         risk_margin,
         InstantClock::now(&*clock),


### PR DESCRIPTION
<s>Changed the format of the expected `attacker.csv` file and parsing to accommodate specifying multiple attackers and also a role for each attacker node. </s>

<s>Roles defined: `Sender`, `Routing` and `Receiver`. </s>

Edit: Allow specifying multiple attackers. 

For current sink attack implementation, it works the same with only attacker node.