### PR TITLE
reputation-builder: write target and attacker pairs to file for debugging

### DIFF
--- a/ln-simln-jamming/src/attacks/sink.rs
+++ b/ln-simln-jamming/src/attacks/sink.rs
@@ -267,6 +267,16 @@ where
     ) -> Result<(), BoxError> {
         // Poll every 5 minutes to check if the attack is done.
         let interval = Duration::from_secs(300);
+        let target_channel_vec: Vec<(PublicKey, u64)> = self
+            .target_channels
+            .iter()
+            .map(|(scid, pubkey)| (*pubkey, *scid))
+            .collect();
+        let attacker_channel_vec: Vec<(PublicKey, u64)> = self
+            .attacker_channels
+            .iter()
+            .map(|(scid, pubkey)| (*pubkey, *scid))
+            .collect();
 
         loop {
             select! {
@@ -294,8 +304,9 @@ where
                     let current_reputation = get_network_reputation(
                         self.reputation_monitor.clone(),
                         self.target_pubkey,
-                        &[self.attacker_pubkey],
-                        &self.target_channels,
+                        vec![self.attacker_pubkey],
+                        &target_channel_vec,
+                        &attacker_channel_vec,
                         self.risk_margin,
                         InstantClock::now(&*self.clock),
                     )

--- a/ln-simln-jamming/src/main.rs
+++ b/ln-simln-jamming/src/main.rs
@@ -55,26 +55,7 @@ async fn main() -> Result<(), BoxError> {
     let tasks = TaskTracker::new();
     let (shutdown, listener) = triggered::trigger();
 
-    let target_channels: HashMap<u64, (PublicKey, String)> = network_dir
-        .sim_network
-        .iter()
-        .filter_map(|channel| {
-            if channel.node_1.pubkey == target_pubkey {
-                Some((
-                    channel.scid.into(),
-                    (channel.node_2.pubkey, channel.node_2.alias.clone()),
-                ))
-            } else if channel.node_2.pubkey == target_pubkey {
-                Some((
-                    channel.scid.into(),
-                    (channel.node_1.pubkey, channel.node_1.alias.clone()),
-                ))
-            } else {
-                None
-            }
-        })
-        .collect();
-
+    let target_channels = network_dir.target_channels();
     let clock = Arc::new(SimulationClock::new(cli.clock_speedup)?);
 
     // Use the channel jamming interceptor and latency for simulated payments.

--- a/ln-simln-jamming/src/main.rs
+++ b/ln-simln-jamming/src/main.rs
@@ -102,7 +102,8 @@ async fn main() -> Result<(), BoxError> {
         }
     });
 
-    let (reputation_state, target_revenue) = network_dir.reputation_summary(cli.attacker_bootstrap);
+    let (reputation_state, target_revenue, _, _) =
+        network_dir.reputation_summary(cli.attacker_bootstrap);
     let reputation_snapshot = reputation_snapshot_from_file(&reputation_state).map_err(|e| {
         format!(
             "could not find reputation snapshot {:?}, try generating one with reputation-builder: {:?}",

--- a/ln-simln-jamming/src/parsing.rs
+++ b/ln-simln-jamming/src/parsing.rs
@@ -373,8 +373,6 @@ where
     R: ReputationMonitor + Send + Sync + 'static,
     M: PeacetimeRevenueMonitor + Send + Sync + 'static,
 {
-    let sim_network = simulation.sim_network.clone();
-
     // NOTE: If you are implementing your own attack and have added the variant to AttackType, you can
     // then do any setup specific to your attack here and return.
     match cli.attack {
@@ -383,9 +381,18 @@ where
                 simulation.attackers.iter().map(|a| a.1).collect();
             let attack = Arc::new(SinkAttack::new(
                 clock,
-                &sim_network,
                 simulation.target.1,
                 attacker_pubkeys,
+                simulation
+                    .target_channels()
+                    .iter()
+                    .map(|(k, v)| (*k, v.0))
+                    .collect(),
+                simulation
+                    .attacker_channels()?
+                    .iter()
+                    .map(|(k, v)| (*k, v.0))
+                    .collect(),
                 risk_margin,
                 reputation_monitor,
                 revenue_monitor,

--- a/ln-simln-jamming/src/parsing.rs
+++ b/ln-simln-jamming/src/parsing.rs
@@ -162,7 +162,10 @@ impl SimulationFiles {
     /// Returns the location of a reputation and target revenue summary for the period of time
     /// that the attacker in the network is bootstrapped for, creating sub-directories to hold
     /// these files is necessary.
-    pub fn reputation_summary(&self, duration: Option<Duration>) -> (PathBuf, PathBuf) {
+    pub fn reputation_summary(
+        &self,
+        duration: Option<Duration>,
+    ) -> (PathBuf, PathBuf, PathBuf, PathBuf) {
         let reputation_dir = self
             .dir
             .join("reputation")
@@ -174,6 +177,8 @@ impl SimulationFiles {
         (
             reputation_dir.join("reputation_summary.csv"),
             reputation_dir.join("target_revenue.txt"),
+            reputation_dir.join("target_reputation.txt"),
+            reputation_dir.join("attacker_reputation.txt"),
         )
     }
 

--- a/ln-simln-jamming/src/test_utils.rs
+++ b/ln-simln-jamming/src/test_utils.rs
@@ -163,20 +163,6 @@ pub fn test_bootstrap_forward(
     }
 }
 
-pub fn get_test_policy(pubkey: PublicKey) -> ChannelPolicy {
-    ChannelPolicy {
-        pubkey,
-        alias: "test_node".into(),
-        max_htlc_count: 483,
-        max_in_flight_msat: 100_000,
-        min_htlc_size_msat: 1000,
-        max_htlc_size_msat: 100_000,
-        cltv_expiry_delta: 40,
-        base_fee: 1000,
-        fee_rate_prop: 1,
-    }
-}
-
 fn setup_test_policy(node: PublicKey) -> ChannelPolicy {
     ChannelPolicy {
         pubkey: node,


### PR DESCRIPTION
Opening this up in draft to pressure myself to clean it up a bit + merge it.

Updates `reputation-builder` tool to write the target and attacker nodes reputation in the eyes of their peers to files along with our reputation files. This isn't used anywhere, but can be helpful for debugging things around reputation values.