### PR TITLE
Only track revenue in one direction

### DIFF
--- a/ln-resource-mgr/src/decaying_average.rs
+++ b/ln-resource-mgr/src/decaying_average.rs
@@ -1,3 +1,4 @@
+use std::fmt::Debug;
 use std::ops::Add;
 use std::time::{Duration, Instant};
 

--- a/ln-resource-mgr/src/decaying_average.rs
+++ b/ln-resource-mgr/src/decaying_average.rs
@@ -19,6 +19,17 @@ impl DecayingAverageOps for i64 {
     }
 }
 
+impl DecayingAverageOps for f64 {
+    fn mul_f64(self, rhs: f64) -> Self {
+        self * rhs
+    }
+    fn saturating_add(self, rhs: Self) -> Self {
+        // f64 type has a specially defined infinity value, at which is just loses precision
+        // rather than overflowing.
+        self + rhs
+    }
+}
+
 /// Tracks a timestamped decaying average, which may be positive or negative. Acts
 #[derive(Clone, Debug)]
 pub(super) struct DecayingAverage<T> {

--- a/ln-resource-mgr/src/forward_manager.rs
+++ b/ln-resource-mgr/src/forward_manager.rs
@@ -53,7 +53,7 @@ struct RevenueAverage {
     /// [`Self::aggregated_revenue_decaying`] will track average revenue over 24 weeks. The two week revenue window
     /// revenue average can then be obtained by adjusting for the window side, which has the effect of evenly
     /// distributing revenue between the windows.
-    aggregated_revenue_decaying: DecayingAverage,
+    aggregated_revenue_decaying: DecayingAverage<i64>,
 }
 
 impl RevenueAverage {

--- a/ln-resource-mgr/src/forward_manager.rs
+++ b/ln-resource-mgr/src/forward_manager.rs
@@ -460,17 +460,8 @@ impl ReputationManager for ForwardManager {
             return Ok(());
         }
 
-        // If the htlc was settled, update *both* the outgoing and incoming channel's revenue trackers.
+        // If the htlc was settled, update the incoming channel's revenue.
         let fee_i64 = i64::try_from(in_flight.fee_msat).unwrap_or(i64::MAX);
-
-        inner_lock
-            .channels
-            .get_mut(&outgoing_channel)
-            .ok_or(ReputationError::ErrOutgoingNotFound(outgoing_channel))?
-            .incoming_direction
-            .revenue
-            .add_value(fee_i64, resolved_instant)?;
-
         inner_lock
             .channels
             .get_mut(&incoming_ref.channel_id)

--- a/ln-resource-mgr/src/forward_manager.rs
+++ b/ln-resource-mgr/src/forward_manager.rs
@@ -121,12 +121,7 @@ pub struct ForwardManagerParams {
 impl Default for ForwardManagerParams {
     fn default() -> Self {
         ForwardManagerParams {
-            reputation_params: ReputationParams {
-                revenue_window: Duration::from_secs(60 * 60 * 24 * 14),
-                reputation_multiplier: 12,
-                resolution_period: Duration::from_secs(90),
-                expected_block_speed: Some(Duration::from_secs(10 * 60)),
-            },
+            reputation_params: ReputationParams::default(),
             general_slot_portion: 30,
             general_liquidity_portion: 30,
             congestion_slot_portion: 20,

--- a/ln-resource-mgr/src/forward_manager.rs
+++ b/ln-resource-mgr/src/forward_manager.rs
@@ -135,14 +135,6 @@ impl Default for ForwardManagerParams {
     }
 }
 
-impl ForwardManagerParams {
-    /// Returns the opportunity cost for the htlc amount and expiry provided, assuming 10 minute blocks.
-    pub fn htlc_opportunity_cost(&self, fee_msat: u64, expiry: u32) -> u64 {
-        self.reputation_params
-            .opportunity_cost(fee_msat, Duration::from_secs(expiry as u64 * 10 * 60))
-    }
-}
-
 /// Defines special actions that can be taken during a simulation that wouldn't otherwise be used in regular operation.
 pub trait SimulationDebugManager {
     fn general_jam_channel(&self, channel: u64) -> Result<(), ReputationError>;

--- a/ln-resource-mgr/src/forward_manager.rs
+++ b/ln-resource-mgr/src/forward_manager.rs
@@ -392,6 +392,7 @@ impl ReputationManager for ForwardManager {
                             slot_count: protected_slot_count,
                             liquidity_msat: protected_liquidity_amount,
                         },
+                        self.params.reputation_params.revenue_window,
                     )?,
                     outgoing_direction: OutgoingChannel::new(
                         self.params.reputation_params,
@@ -525,6 +526,8 @@ impl ReputationManager for ForwardManager {
                 outgoing_channel,
                 in_flight.incoming_amt_msat,
                 in_flight.bucket.clone(),
+                resolution == ForwardResolution::Settled,
+                resolved_instant,
             )?;
 
         inner_lock

--- a/ln-resource-mgr/src/forward_manager.rs
+++ b/ln-resource-mgr/src/forward_manager.rs
@@ -415,6 +415,13 @@ impl ReputationManager for ForwardManager {
                             liquidity_msat: protected_liquidity_amount,
                         },
                         self.params.reputation_params.revenue_window,
+                        channel_reputation.map(|snapshot| {
+                            (
+                                snapshot.incoming_slot_utilization,
+                                snapshot.incoming_liquidity_utilization,
+                                add_ins,
+                            )
+                        }),
                     )?,
                     outgoing_direction: OutgoingChannel::new(
                         self.params.reputation_params,

--- a/ln-resource-mgr/src/forward_manager.rs
+++ b/ln-resource-mgr/src/forward_manager.rs
@@ -1,4 +1,3 @@
-use crate::decaying_average::DecayingAverage;
 use crate::htlc_manager::{InFlightHtlc, InFlightManager};
 use crate::incoming_channel::{BucketParameters, IncomingChannel};
 use crate::outgoing_channel::OutgoingChannel;
@@ -10,7 +9,7 @@ use crate::{
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::sync::Mutex;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 /// Tracks reputation and revenue for a channel.
 #[derive(Debug)]
@@ -18,93 +17,6 @@ struct TrackedChannel {
     capacity_msat: u64,
     outgoing_direction: OutgoingChannel,
     incoming_direction: IncomingChannel,
-    revenue: RevenueAverage,
-}
-
-/// Tracks the average bi-directional revenue of a channel over multiple windows of time to smooth out this value over
-/// time. The number of windows that this average is tracked over is determined by [`Self::window_count`].
-///
-/// For example: if we're interested in tracking revenue over two weeks and we're interested in aggregating over ten
-/// windows, we will track the aggregate revenue over the last ten two week windows.
-#[derive(Debug)]
-struct RevenueAverage {
-    /// Tracks when the average started to be tracked. Used to track the actual number of windows we've been tracking
-    /// for when we haven't yet reached the full [`Self::window_count`]. This gives us some robustness on startup,
-    /// rather than underestimating.
-    ///
-    /// For example: if we've only been tracking for two windows of time, and we're averaging over ten windows we only
-    /// want to average across the two tracked windows (rather than averaging over ten and including eight windows that
-    /// are effectively zero).
-    start_ins: Instant,
-    /// The number of windows that we want to track our average revenue.
-    window_count: u8,
-    /// The length of the window we're tracking average values for.
-    window_duration: Duration,
-    /// Tracks the channel's average bi-directional revenue over the full period of time that we're interested in
-    /// aggregating. This is a decent approximation of tracking each window separately, and saves us needing to store
-    /// multiple data points per channel.
-    ///
-    /// For example:
-    /// - 2 week revenue period
-    /// - 12 window_count
-    ///
-    /// [`Self::aggregated_revenue_decaying`] will track average revenue over 24 weeks. The two week revenue window
-    /// revenue average can then be obtained by adjusting for the window side, which has the effect of evenly
-    /// distributing revenue between the windows.
-    aggregated_revenue_decaying: DecayingAverage<i64>,
-}
-
-impl RevenueAverage {
-    fn new(params: &ReputationParams, start_ins: Instant) -> Self {
-        RevenueAverage {
-            start_ins,
-            window_count: params.reputation_multiplier,
-            window_duration: params.revenue_window,
-            aggregated_revenue_decaying: DecayingAverage::new(
-                params.revenue_window * params.reputation_multiplier.into(),
-            ),
-        }
-    }
-
-    /// Decays the tracked value to its value at the instant provided and returns the updated value. The access_instant
-    /// must be after the last_updated time of the decaying average, tolerant to nanosecond differences.
-    fn add_value(&mut self, value: i64, update_time: Instant) -> Result<i64, ReputationError> {
-        self.aggregated_revenue_decaying
-            .add_value(value, update_time)
-    }
-
-    /// The number of full windows that have been tracked since the average started. Returned as a float so that the
-    /// average can be gradually scaled.
-    fn windows_tracked(&self, access_ins: Instant) -> f64 {
-        access_ins.duration_since(self.start_ins).as_secs_f64() / self.window_duration.as_secs_f64()
-    }
-
-    /// Updates the current value of the decaying average and then adds the new value provided. The value provided
-    /// will act as a saturating add if it exceeds i64::MAX.
-    fn value_at_instant(&mut self, access_ins: Instant) -> Result<i64, ReputationError> {
-        // If we're below our count of windows, we only want to aggregate for the amount of windows we've tracked so
-        // far. If we've reached out count, we just use that because the average only tracks this number of windows.
-        let windows_tracked = self.windows_tracked(access_ins);
-        let window_divisor = f64::min(
-            // If less than one window has been tracked, this will be a fraction which will inflate our revenue so we
-            // just flatten it to 1.
-            // TODO: better strategy for first window?
-            if windows_tracked < 1.0 {
-                1.0
-            } else {
-                windows_tracked
-            },
-            self.window_count as f64,
-        );
-
-        // To give the value for this longer-running average over an equivalent two week period, we just divide it by
-        // the number of windows we're counting.
-        Ok((self
-            .aggregated_revenue_decaying
-            .value_at_instant(access_ins)? as f64
-            / window_divisor)
-            .round() as i64)
-    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -199,6 +111,7 @@ impl ForwardManagerImpl {
             ))?;
 
         let incoming_revenue_threshold = incoming_channel
+            .incoming_direction
             .revenue
             .value_at_instant(forward.added_at)?;
 
@@ -366,26 +279,19 @@ impl ReputationManager for ForwardManager {
                     .as_ref()
                     .map(|channel| (channel.outgoing_reputation, add_ins));
 
-                let revenue = match &channel_reputation {
-                    Some(channel) => {
-                        if channel.capacity_msat != capacity_msat {
-                            return Err(ReputationError::ErrChannelCapacityMismatch(
-                                capacity_msat,
-                                channel.capacity_msat,
-                            ));
-                        }
-
-                        let mut revenue =
-                            RevenueAverage::new(&self.params.reputation_params, add_ins);
-                        revenue.add_value(channel.incoming_revenue, add_ins)?;
-                        revenue
+                if let Some(ref channel) = channel_reputation {
+                    if channel.capacity_msat != capacity_msat {
+                        return Err(ReputationError::ErrChannelCapacityMismatch(
+                            capacity_msat,
+                            channel.capacity_msat,
+                        ));
                     }
-                    None => RevenueAverage::new(&self.params.reputation_params, add_ins),
-                };
+                }
 
                 v.insert(TrackedChannel {
                     capacity_msat,
                     incoming_direction: IncomingChannel::new(
+                        &self.params.reputation_params,
                         channel_id,
                         BucketParameters {
                             slot_count: general_slot_count,
@@ -399,12 +305,12 @@ impl ReputationManager for ForwardManager {
                             slot_count: protected_slot_count,
                             liquidity_msat: protected_liquidity_amount,
                         },
-                        self.params.reputation_params.revenue_window,
+                        add_ins,
                         channel_reputation.map(|snapshot| {
                             (
                                 snapshot.incoming_slot_utilization,
                                 snapshot.incoming_liquidity_utilization,
-                                add_ins,
+                                snapshot.incoming_revenue,
                             )
                         }),
                     )?,
@@ -412,7 +318,6 @@ impl ReputationManager for ForwardManager {
                         self.params.reputation_params,
                         outgoing_reputation,
                     )?,
-                    revenue,
                 });
 
                 Ok(())
@@ -562,6 +467,7 @@ impl ReputationManager for ForwardManager {
             .channels
             .get_mut(&outgoing_channel)
             .ok_or(ReputationError::ErrOutgoingNotFound(outgoing_channel))?
+            .incoming_direction
             .revenue
             .add_value(fee_i64, resolved_instant)?;
 
@@ -571,6 +477,7 @@ impl ReputationManager for ForwardManager {
             .ok_or(ReputationError::ErrIncomingNotFound(
                 incoming_ref.channel_id,
             ))?
+            .incoming_direction
             .revenue
             .add_value(fee_i64, resolved_instant)?;
 
@@ -603,7 +510,10 @@ impl ReputationManager for ForwardManager {
                     outgoing_reputation: channel
                         .outgoing_direction
                         .outgoing_reputation(access_ins)?,
-                    incoming_revenue: channel.revenue.value_at_instant(access_ins)?,
+                    incoming_revenue: channel
+                        .incoming_direction
+                        .revenue
+                        .value_at_instant(access_ins)?,
                     incoming_slot_utilization,
                     incoming_liquidity_utilization,
                 },
@@ -618,7 +528,7 @@ impl ReputationManager for ForwardManager {
 mod tests {
     use std::time::{Duration, Instant};
 
-    use super::{ForwardManagerParams, RevenueAverage};
+    use super::ForwardManagerParams;
     use crate::{
         forward_manager::{ForwardManager, SimulationDebugManager},
         AccountableSignal, ChannelSnapshot, FailureReason, ForwardingOutcome, HtlcRef,
@@ -658,91 +568,6 @@ mod tests {
             .incoming_direction;
         assert!(channel_0.general_bucket.params.slot_count == 0);
         assert!(channel_0.congestion_bucket.slot_count == 0);
-    }
-
-    #[test]
-    fn test_revenue_average() {
-        let params = ReputationParams {
-            revenue_window: Duration::from_secs(60 * 60 * 24 * 14),
-            reputation_multiplier: 10,
-            resolution_period: Duration::from_secs(90),
-            expected_block_speed: None,
-        };
-
-        let now = Instant::now();
-        let mut revenue_average = RevenueAverage::new(&params, now);
-
-        assert_eq!(revenue_average.value_at_instant(now).unwrap(), 0);
-
-        let value = 10_000;
-
-        // When we're right at the beginning our our tracking, revenue shouldn't be divided over multiple periods,
-        // because we haven't tracked that long yet.
-        revenue_average.add_value(value, now).unwrap();
-        assert_eq!(revenue_average.value_at_instant(now).unwrap(), value);
-
-        // Progress our timestamp to the end of the first window of time. We're testing the division of total revenue
-        // tracked over windows, not the actual decaying average, so we peek under the hood to get the value that we've
-        // decayed to and then assert that
-        let end_first_window = now.checked_add(params.revenue_window).unwrap();
-        let decayed_value = revenue_average
-            .aggregated_revenue_decaying
-            .value_at_instant(end_first_window)
-            .unwrap();
-
-        assert_eq!(
-            revenue_average.value_at_instant(end_first_window).unwrap(),
-            decayed_value
-        );
-
-        // Move to half way through the second window, the value should now be split between two periods. Again, we'll
-        // peek under at the decayed value and then check that it's being split over periods.
-        let half_second_window = end_first_window
-            .checked_add(params.revenue_window / 2)
-            .unwrap();
-        let decayed_value = revenue_average
-            .aggregated_revenue_decaying
-            .value_at_instant(half_second_window)
-            .unwrap();
-
-        assert_eq!(
-            revenue_average
-                .value_at_instant(half_second_window)
-                .unwrap(),
-            (decayed_value as f64 / 1.5).round() as i64,
-        );
-
-        // Finally, test that once we reach our total window count, we don't continue to divide by more and more
-        // windows.
-        let final_window = now
-            .checked_add(params.revenue_window * params.reputation_multiplier.into())
-            .unwrap();
-        let decayed_value = revenue_average
-            .aggregated_revenue_decaying
-            .value_at_instant(final_window)
-            .unwrap();
-
-        assert_eq!(
-            revenue_average.value_at_instant(final_window).unwrap(),
-            (decayed_value as f64 / params.reputation_multiplier as f64).round() as i64,
-        );
-
-        // Once we get beyond the window count, it's just the decay at play and we're using the count to divide our
-        // running average.
-        let beyond_final_window = now
-            .checked_add(params.revenue_window * params.reputation_multiplier.into() * 5)
-            .unwrap();
-        let decayed_value = revenue_average
-            .aggregated_revenue_decaying
-            .value_at_instant(beyond_final_window)
-            .unwrap();
-
-        assert_eq!(
-            revenue_average
-                .value_at_instant(beyond_final_window)
-                .unwrap(),
-            (decayed_value as f64 / params.reputation_multiplier as f64).round() as i64,
-        );
     }
 
     fn test_forward_manager_params() -> ForwardManagerParams {

--- a/ln-resource-mgr/src/forward_manager.rs
+++ b/ln-resource-mgr/src/forward_manager.rs
@@ -377,7 +377,7 @@ impl ReputationManager for ForwardManager {
 
                         let mut revenue =
                             RevenueAverage::new(&self.params.reputation_params, add_ins);
-                        revenue.add_value(channel.bidirectional_revenue, add_ins)?;
+                        revenue.add_value(channel.incoming_revenue, add_ins)?;
                         revenue
                     }
                     None => RevenueAverage::new(&self.params.reputation_params, add_ins),
@@ -603,7 +603,7 @@ impl ReputationManager for ForwardManager {
                     outgoing_reputation: channel
                         .outgoing_direction
                         .outgoing_reputation(access_ins)?,
-                    bidirectional_revenue: channel.revenue.value_at_instant(access_ins)?,
+                    incoming_revenue: channel.revenue.value_at_instant(access_ins)?,
                     incoming_slot_utilization,
                     incoming_liquidity_utilization,
                 },
@@ -777,7 +777,7 @@ mod tests {
             capacity_msat: 10_000_000,
             non_general_slots: 100,
             outgoing_reputation: 1000,
-            bidirectional_revenue: 500,
+            incoming_revenue: 500,
             incoming_liquidity_utilization: 0.0,
             incoming_slot_utilization: 0.0,
         };
@@ -807,7 +807,7 @@ mod tests {
         // Check values on 2nd channel added from snapshot
         assert!(channels.get(&1).unwrap().capacity_msat == channel_capacity);
         assert!(channels.get(&1).unwrap().outgoing_reputation == 1000);
-        assert!(channels.get(&1).unwrap().bidirectional_revenue == 500);
+        assert!(channels.get(&1).unwrap().incoming_revenue == 500);
 
         assert!(fwd_manager.remove_channel(0).is_ok());
         assert!(
@@ -877,7 +877,7 @@ mod tests {
             capacity_msat: channel_capacity,
             non_general_slots: 100,
             outgoing_reputation: 10_000_000,
-            bidirectional_revenue: 1_000_000,
+            incoming_revenue: 1_000_000,
             incoming_liquidity_utilization: 0.0,
             incoming_slot_utilization: 0.0,
         };
@@ -929,7 +929,7 @@ mod tests {
             capacity_msat: channel_capacity,
             non_general_slots: 100,
             outgoing_reputation: 10_000_000,
-            bidirectional_revenue: 1_000_000,
+            incoming_revenue: 1_000_000,
             incoming_liquidity_utilization: 0.0,
             incoming_slot_utilization: 0.0,
         };

--- a/ln-resource-mgr/src/forward_manager.rs
+++ b/ln-resource-mgr/src/forward_manager.rs
@@ -1,5 +1,5 @@
 use crate::decaying_average::DecayingAverage;
-use crate::htlc_manager::{ChannelFilter, InFlightHtlc, InFlightManager};
+use crate::htlc_manager::{InFlightHtlc, InFlightManager};
 use crate::incoming_channel::{BucketParameters, IncomingChannel};
 use crate::outgoing_channel::OutgoingChannel;
 use crate::{
@@ -196,9 +196,9 @@ impl ForwardManagerImpl {
             reputation_check: ReputationCheck {
                 reputation: outgoing_reputation,
                 revenue_threshold: incoming_revenue_threshold,
-                in_flight_total_risk: self.htlcs.channel_in_flight_risk(
-                    ChannelFilter::OutgoingChannel(forward.outgoing_channel_id),
-                ),
+                in_flight_total_risk: self
+                    .htlcs
+                    .channel_in_flight_risk(forward.outgoing_channel_id),
                 htlc_risk: self
                     .htlcs
                     .htlc_risk(forward.fee_msat(), forward.expiry_in_height),

--- a/ln-resource-mgr/src/htlc_manager.rs
+++ b/ln-resource-mgr/src/htlc_manager.rs
@@ -35,6 +35,12 @@ impl ReputationParams {
         (hold_time.as_secs() / self.resolution_period.as_secs()).saturating_mul(fee_msat)
     }
 
+    /// Calculates the opportunity_cost of a htlc being held on the channel for the number of blocks
+    /// provided, assuming 10 minute blocks.
+    pub fn opportunity_cost_from_blocks(&self, fee_msat: u64, expiry: u32) -> u64 {
+        self.opportunity_cost(fee_msat, Duration::from_secs(expiry as u64 * 10 * 60))
+    }
+
     /// Calculates the worst case reputation damage of a htlc, assuming it'll be held for its full expiry_delta.
     pub(super) fn htlc_risk(&self, fee_msat: u64, expiry_delta: u32) -> u64 {
         let max_hold_time = self

--- a/ln-resource-mgr/src/htlc_manager.rs
+++ b/ln-resource-mgr/src/htlc_manager.rs
@@ -28,6 +28,17 @@ pub struct ReputationParams {
     pub expected_block_speed: Option<Duration>,
 }
 
+impl Default for ReputationParams {
+    fn default() -> Self {
+        ReputationParams {
+            revenue_window: Duration::from_secs(60 * 60 * 24 * 14),
+            reputation_multiplier: 12,
+            resolution_period: Duration::from_secs(90),
+            expected_block_speed: Some(Duration::from_secs(10 * 60)),
+        }
+    }
+}
+
 impl ReputationParams {
     /// Calculates the opportunity_cost of a htlc being held on our channel - allowing one [`reputation_period`]'s
     /// grace period, then charging for every subsequent period.

--- a/ln-resource-mgr/src/incoming_channel.rs
+++ b/ln-resource-mgr/src/incoming_channel.rs
@@ -6,8 +6,107 @@ use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
 use crate::decaying_average::DecayingAverage;
-use crate::{ReputationError, ResourceBucketType};
+use crate::{ReputationError, ReputationParams, ResourceBucketType};
 
+/// Tracks the average bi-directional revenue of a channel over multiple windows of time to smooth out this value over
+/// time. The number of windows that this average is tracked over is determined by [`Self::window_count`].
+///
+/// For example: if we're interested in tracking revenue over two weeks and we're interested in aggregating over ten
+/// windows, we will track the aggregate revenue over the last ten two week windows.
+#[derive(Debug)]
+pub(super) struct RevenueAverage {
+    /// Tracks when the average started to be tracked. Used to track the actual number of windows we've been tracking
+    /// for when we haven't yet reached the full [`Self::window_count`]. This gives us some robustness on startup,
+    /// rather than underestimating.
+    ///
+    /// For example: if we've only been tracking for two windows of time, and we're averaging over ten windows we only
+    /// want to average across the two tracked windows (rather than averaging over ten and including eight windows that
+    /// are effectively zero).
+    start_ins: Instant,
+    /// The number of windows that we want to track our average revenue.
+    window_count: u8,
+    /// The length of the window we're tracking average values for.
+    window_duration: Duration,
+    /// Tracks the channel's average bi-directional revenue over the full period of time that we're interested in
+    /// aggregating. This is a decent approximation of tracking each window separately, and saves us needing to store
+    /// multiple data points per channel.
+    ///
+    /// For example:
+    /// - 2 week revenue period
+    /// - 12 window_count
+    ///
+    /// [`Self::aggregated_revenue_decaying`] will track average revenue over 24 weeks. The two week revenue window
+    /// revenue average can then be obtained by adjusting for the window side, which has the effect of evenly
+    /// distributing revenue between the windows.
+    aggregated_revenue_decaying: DecayingAverage<i64>,
+}
+
+impl RevenueAverage {
+    fn new(
+        params: &ReputationParams,
+        start_ins: Instant,
+        start_value: Option<i64>,
+    ) -> Result<Self, ReputationError> {
+        let mut s = RevenueAverage {
+            start_ins,
+            window_count: params.reputation_multiplier,
+            window_duration: params.revenue_window,
+            aggregated_revenue_decaying: DecayingAverage::new(
+                params.revenue_window * params.reputation_multiplier.into(),
+            ),
+        };
+
+        if let Some(start) = start_value {
+            s.add_value(start, start_ins)?;
+        }
+
+        Ok(s)
+    }
+
+    /// Decays the tracked value to its value at the instant provided and returns the updated value. The access_instant
+    /// must be after the last_updated time of the decaying average, tolerant to nanosecond differences.
+    pub(super) fn add_value(
+        &mut self,
+        value: i64,
+        update_time: Instant,
+    ) -> Result<i64, ReputationError> {
+        self.aggregated_revenue_decaying
+            .add_value(value, update_time)
+    }
+
+    /// The number of full windows that have been tracked since the average started. Returned as a float so that the
+    /// average can be gradually scaled.
+    fn windows_tracked(&self, access_ins: Instant) -> f64 {
+        access_ins.duration_since(self.start_ins).as_secs_f64() / self.window_duration.as_secs_f64()
+    }
+
+    /// Updates the current value of the decaying average and then adds the new value provided. The value provided
+    /// will act as a saturating add if it exceeds i64::MAX.
+    pub(super) fn value_at_instant(&mut self, access_ins: Instant) -> Result<i64, ReputationError> {
+        // If we're below our count of windows, we only want to aggregate for the amount of windows we've tracked so
+        // far. If we've reached out count, we just use that because the average only tracks this number of windows.
+        let windows_tracked = self.windows_tracked(access_ins);
+        let window_divisor = f64::min(
+            // If less than one window has been tracked, this will be a fraction which will inflate our revenue so we
+            // just flatten it to 1.
+            // TODO: better strategy for first window?
+            if windows_tracked < 1.0 {
+                1.0
+            } else {
+                windows_tracked
+            },
+            self.window_count as f64,
+        );
+
+        // To give the value for this longer-running average over an equivalent two week period, we just divide it by
+        // the number of windows we're counting.
+        Ok((self
+            .aggregated_revenue_decaying
+            .value_at_instant(access_ins)? as f64
+            / window_divisor)
+            .round() as i64)
+    }
+}
 /// Describes the size of a resource bucket.
 #[derive(Clone, Debug)]
 pub struct BucketParameters {
@@ -33,23 +132,31 @@ pub(super) struct IncomingChannel {
 
     /// Tracks the rate at which protected and congested resources are utilized on the channel.
     pub(super) utilization: ChannelUtilization,
+
+    /// The revenue that this node has earned us as the incoming forwarder.
+    pub(super) revenue: RevenueAverage,
 }
 
 impl IncomingChannel {
     pub(super) fn new(
+        params: &ReputationParams,
         scid: u64,
         general_bucket: BucketParameters,
         congestion_bucket: BucketParameters,
         protected_bucket: BucketParameters,
-        utilization_period: Duration,
-        // Starting stat for (slots, liquidity) utilization.
-        utilization_start: Option<(f64, f64, Instant)>,
+        start_ins: Instant,
+        // Starting state for (slots, liquidity, revenue).
+        start_state: Option<(f64, f64, i64)>,
     ) -> Result<Self, ReputationError> {
         Ok(Self {
             general_bucket: GeneralBucket::new(scid, general_bucket)?,
             congestion_bucket,
             protected_bucket,
-            utilization: ChannelUtilization::new(utilization_period, utilization_start)?,
+            utilization: ChannelUtilization::new(
+                params.revenue_window,
+                start_state.map(|v| (v.0, v.1, start_ins)),
+            )?,
+            revenue: RevenueAverage::new(params, start_ins, start_state.map(|v| v.2))?,
         })
     }
 
@@ -624,5 +731,90 @@ mod tests {
 
         bucket.remove_htlc(scid_2, htlc_amt).unwrap();
         bucket.remove_htlc(scid_1, htlc_amt).unwrap();
+    }
+
+    #[test]
+    fn test_revenue_average() {
+        let params = ReputationParams {
+            revenue_window: Duration::from_secs(60 * 60 * 24 * 14),
+            reputation_multiplier: 10,
+            resolution_period: Duration::from_secs(90),
+            expected_block_speed: None,
+        };
+
+        let now = Instant::now();
+        let mut revenue_average = RevenueAverage::new(&params, now, None).unwrap();
+
+        assert_eq!(revenue_average.value_at_instant(now).unwrap(), 0);
+
+        let value = 10_000;
+
+        // When we're right at the beginning our our tracking, revenue shouldn't be divided over multiple periods,
+        // because we haven't tracked that long yet.
+        revenue_average.add_value(value, now).unwrap();
+        assert_eq!(revenue_average.value_at_instant(now).unwrap(), value);
+
+        // Progress our timestamp to the end of the first window of time. We're testing the division of total revenue
+        // tracked over windows, not the actual decaying average, so we peek under the hood to get the value that we've
+        // decayed to and then assert that
+        let end_first_window = now.checked_add(params.revenue_window).unwrap();
+        let decayed_value = revenue_average
+            .aggregated_revenue_decaying
+            .value_at_instant(end_first_window)
+            .unwrap();
+
+        assert_eq!(
+            revenue_average.value_at_instant(end_first_window).unwrap(),
+            decayed_value
+        );
+
+        // Move to half way through the second window, the value should now be split between two periods. Again, we'll
+        // peek under at the decayed value and then check that it's being split over periods.
+        let half_second_window = end_first_window
+            .checked_add(params.revenue_window / 2)
+            .unwrap();
+        let decayed_value = revenue_average
+            .aggregated_revenue_decaying
+            .value_at_instant(half_second_window)
+            .unwrap();
+
+        assert_eq!(
+            revenue_average
+                .value_at_instant(half_second_window)
+                .unwrap(),
+            (decayed_value as f64 / 1.5).round() as i64,
+        );
+
+        // Finally, test that once we reach our total window count, we don't continue to divide by more and more
+        // windows.
+        let final_window = now
+            .checked_add(params.revenue_window * params.reputation_multiplier.into())
+            .unwrap();
+        let decayed_value = revenue_average
+            .aggregated_revenue_decaying
+            .value_at_instant(final_window)
+            .unwrap();
+
+        assert_eq!(
+            revenue_average.value_at_instant(final_window).unwrap(),
+            (decayed_value as f64 / params.reputation_multiplier as f64).round() as i64,
+        );
+
+        // Once we get beyond the window count, it's just the decay at play and we're using the count to divide our
+        // running average.
+        let beyond_final_window = now
+            .checked_add(params.revenue_window * params.reputation_multiplier.into() * 5)
+            .unwrap();
+        let decayed_value = revenue_average
+            .aggregated_revenue_decaying
+            .value_at_instant(beyond_final_window)
+            .unwrap();
+
+        assert_eq!(
+            revenue_average
+                .value_at_instant(beyond_final_window)
+                .unwrap(),
+            (decayed_value as f64 / params.reputation_multiplier as f64).round() as i64,
+        );
     }
 }

--- a/ln-resource-mgr/src/incoming_channel.rs
+++ b/ln-resource-mgr/src/incoming_channel.rs
@@ -110,6 +110,21 @@ impl IncomingChannel {
             access_instant,
         )
     }
+
+    /// Returns slot and liquidity utilization for the channel.
+    pub(super) fn utilization_values(
+        &mut self,
+        access_instant: Instant,
+    ) -> Result<(f64, f64), ReputationError> {
+        Ok((
+            self.utilization
+                .slot_utilization
+                .value_at_instant(access_instant)?,
+            self.utilization
+                .liquidity_utilization
+                .value_at_instant(access_instant)?,
+        ))
+    }
 }
 
 #[derive(Debug)]

--- a/ln-resource-mgr/src/lib.rs
+++ b/ln-resource-mgr/src/lib.rs
@@ -515,11 +515,15 @@ impl ProposedForward {
 }
 
 /// Provides a snapshot of the reputation and revenue values tracked for a channel.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct ChannelSnapshot {
     pub capacity_msat: u64,
+    /// Total count of congestion and protected slots.
+    pub non_general_slots: u16,
     pub outgoing_reputation: i64,
     pub bidirectional_revenue: i64,
+    pub incoming_slot_utilization: f64,
+    pub incoming_liquidity_utilization: f64,
 }
 
 /// Validates that an msat amount doesn't exceed the total supply cap of bitcoin and casts to i64 to be used in

--- a/ln-resource-mgr/src/lib.rs
+++ b/ln-resource-mgr/src/lib.rs
@@ -521,7 +521,7 @@ pub struct ChannelSnapshot {
     /// Total count of congestion and protected slots.
     pub non_general_slots: u16,
     pub outgoing_reputation: i64,
-    pub bidirectional_revenue: i64,
+    pub incoming_revenue: i64,
     pub incoming_slot_utilization: f64,
     pub incoming_liquidity_utilization: f64,
 }

--- a/ln-resource-mgr/src/outgoing_channel.rs
+++ b/ln-resource-mgr/src/outgoing_channel.rs
@@ -13,7 +13,7 @@ pub(super) struct OutgoingChannel {
 
     /// The reputation that the channel has accrued as the outgoing link in htlc forwards. Tracked as a decaying
     /// average over the reputation_window that the tracker is created with.
-    outgoing_reputation: DecayingAverage,
+    outgoing_reputation: DecayingAverage<i64>,
 
     /// Tracks the last instant that the outgoing channel misused congested resources, if any.
     last_congestion_misuse: Option<Instant>,

--- a/ln-simln-jamming/src/attacks/utils.rs
+++ b/ln-simln-jamming/src/attacks/utils.rs
@@ -106,7 +106,7 @@ pub async fn build_reputation<R: ReputationMonitor>(
     let current_target_revenue = channels
         .get(&target_channel.1)
         .ok_or(format!("target channel {} not found", target_channel.1))?
-        .bidirectional_revenue;
+        .incoming_revenue;
 
     let current_attacker_reputation = channels
         .get(&last_hop_channel)
@@ -169,7 +169,7 @@ pub async fn build_reputation<R: ReputationMonitor>(
     let target_revenue = channels
         .get(&target_channel.1)
         .ok_or(format!("target channel {} not found", target_channel.1))?
-        .bidirectional_revenue;
+        .incoming_revenue;
 
     let attacker_reputation = channels
         .get(&last_hop_channel)

--- a/ln-simln-jamming/src/attacks/utils.rs
+++ b/ln-simln-jamming/src/attacks/utils.rs
@@ -269,6 +269,7 @@ mod tests {
         attacks::utils::{
             build_custom_route, build_reputation, BuildReputationParams, CLTV_OFFSET_LDK,
         },
+        clock::InstantClock,
         records_from_signal,
         reputation_interceptor::{ChannelJammer, ReputationInterceptor},
         test_utils::{get_random_keypair, setup_test_edge},
@@ -432,8 +433,9 @@ mod tests {
         let target_channel_id: u64 = edges[2].scid.into();
 
         let clock = Arc::new(SimulationClock::new(1).unwrap());
+        let now = InstantClock::now(&*clock);
         let reputation_interceptor: ReputationInterceptor<BatchForwardWriter, ForwardManager> =
-            ReputationInterceptor::new_for_network(params, &edges, Arc::clone(&clock), None)
+            ReputationInterceptor::new_for_network(params, &edges, now, Arc::clone(&clock), None)
                 .unwrap();
 
         let network_graph = {

--- a/ln-simln-jamming/src/attacks/utils.rs
+++ b/ln-simln-jamming/src/attacks/utils.rs
@@ -219,7 +219,11 @@ fn fee_to_build_reputation(
 
                 let target_hop = &path.hops[target_idx];
                 let current_htlc_risk = forward_params
-                    .htlc_opportunity_cost(target_hop.fee_msat, cltv_expiry + CLTV_OFFSET_LDK);
+                    .reputation_params
+                    .opportunity_cost_from_blocks(
+                        target_hop.fee_msat,
+                        cltv_expiry + CLTV_OFFSET_LDK,
+                    );
 
                 total_htlc_risk += current_htlc_risk;
             }
@@ -349,7 +353,7 @@ mod tests {
         let htlc_risk = {
             let mut risk = 0;
             for htlc in htlc_amounts.iter() {
-                risk += fwd_params.htlc_opportunity_cost(
+                risk += fwd_params.reputation_params.opportunity_cost_from_blocks(
                     (*htlc as f64 * fee_pct) as u64,
                     expiry_delta + CLTV_OFFSET_LDK,
                 );

--- a/ln-simln-jamming/src/bin/forward_builder.rs
+++ b/ln-simln-jamming/src/bin/forward_builder.rs
@@ -60,6 +60,7 @@ async fn main() -> Result<(), BoxError> {
     let network_dir = SimulationFiles::new(cli.network.network_dir.clone(), cli.traffic_type)?;
 
     let clock = Arc::new(SimulationClock::new(1000)?);
+    let now = InstantClock::now(&*clock);
     let tasks = TaskTracker::new();
 
     // Forwarding traffic can either be created for the peacetime or attacktime graphs. We'll
@@ -74,6 +75,7 @@ async fn main() -> Result<(), BoxError> {
     let reputation_interceptor = Arc::new(ReputationInterceptor::new_for_network(
         cli.reputation_params.into(),
         &network_dir.sim_network,
+        now,
         clock.clone(),
         Some(Arc::new(Mutex::new(BootstrapWriter::new(
             clock.clone(),

--- a/ln-simln-jamming/src/bin/reputation_builder.rs
+++ b/ln-simln-jamming/src/bin/reputation_builder.rs
@@ -160,7 +160,7 @@ async fn main() -> Result<(), BoxError> {
         "channel_capacity",
         "non_general_slots",
         "outgoing_reputation",
-        "bidirectional_revenue",
+        "incoming_revenue",
         "slot_utilization",
         "liquidity_utilization",
     ])?;
@@ -177,7 +177,7 @@ async fn main() -> Result<(), BoxError> {
                 channel.1.capacity_msat,
                 channel.1.non_general_slots,
                 channel.1.outgoing_reputation,
-                channel.1.bidirectional_revenue,
+                channel.1.incoming_revenue,
                 channel.1.incoming_slot_utilization,
                 channel.1.incoming_liquidity_utilization,
             ))?;

--- a/ln-simln-jamming/src/bin/reputation_builder.rs
+++ b/ln-simln-jamming/src/bin/reputation_builder.rs
@@ -156,8 +156,11 @@ async fn main() -> Result<(), BoxError> {
         "pubkey",
         "scid",
         "channel_capacity",
+        "non_general_slots",
         "outgoing_reputation",
         "bidirectional_revenue",
+        "slot_utilization",
+        "liquidity_utilization",
     ])?;
 
     for pubkey in node_pubkeys {
@@ -170,8 +173,11 @@ async fn main() -> Result<(), BoxError> {
                 pubkey,
                 channel.0,
                 channel.1.capacity_msat,
+                channel.1.non_general_slots,
                 channel.1.outgoing_reputation,
                 channel.1.bidirectional_revenue,
+                channel.1.incoming_slot_utilization,
+                channel.1.incoming_liquidity_utilization,
             ))?;
         }
     }

--- a/ln-simln-jamming/src/bin/reputation_builder.rs
+++ b/ln-simln-jamming/src/bin/reputation_builder.rs
@@ -121,11 +121,13 @@ async fn main() -> Result<(), BoxError> {
     };
 
     let clock = Arc::new(SimulationClock::new(1)?);
+    let now = InstantClock::now(&*clock);
     let reputation_clock = Arc::clone(&clock);
     let mut reputation_interceptor: ReputationInterceptor<BatchForwardWriter, ForwardManager> =
         ReputationInterceptor::new_for_network(
             forward_params,
             &network_dir.sim_network,
+            now,
             reputation_clock,
             None,
         )?;

--- a/ln-simln-jamming/src/lib.rs
+++ b/ln-simln-jamming/src/lib.rs
@@ -161,7 +161,7 @@ fn count_reputation_pairs(
 
             **scid != outgoing_channel
                 && outgoing_channel_snapshot.outgoing_reputation
-                    >= snapshot.bidirectional_revenue + risk_margin.round() as i64
+                    >= snapshot.incoming_revenue + risk_margin.round() as i64
         })
         .count())
 }
@@ -250,7 +250,7 @@ mod tests {
                                 capacity_msat: 200_000,
                                 non_general_slots: 100,
                                 outgoing_reputation: 100,
-                                bidirectional_revenue: 15,
+                                incoming_revenue: 15,
                                 incoming_liquidity_utilization: 0.0,
                                 incoming_slot_utilization: 0.0,
                             },
@@ -261,7 +261,7 @@ mod tests {
                                 capacity_msat: 200_000,
                                 non_general_slots: 100,
                                 outgoing_reputation: 150,
-                                bidirectional_revenue: 110,
+                                incoming_revenue: 110,
                                 incoming_liquidity_utilization: 0.0,
                                 incoming_slot_utilization: 0.0,
                             },
@@ -272,7 +272,7 @@ mod tests {
                                 capacity_msat: 200_000,
                                 non_general_slots: 100,
                                 outgoing_reputation: 200,
-                                bidirectional_revenue: 90,
+                                incoming_revenue: 90,
                                 incoming_liquidity_utilization: 0.0,
                                 incoming_slot_utilization: 0.0,
                             },
@@ -283,7 +283,7 @@ mod tests {
                                 capacity_msat: 200_000,
                                 non_general_slots: 100,
                                 outgoing_reputation: 75,
-                                bidirectional_revenue: 100,
+                                incoming_revenue: 100,
                                 incoming_liquidity_utilization: 0.0,
                                 incoming_slot_utilization: 0.0,
                             },
@@ -297,7 +297,7 @@ mod tests {
                                 capacity_msat: 200_000,
                                 non_general_slots: 100,
                                 outgoing_reputation: 500,
-                                bidirectional_revenue: 15,
+                                incoming_revenue: 15,
                                 incoming_liquidity_utilization: 0.0,
                                 incoming_slot_utilization: 0.0,
                             },
@@ -308,7 +308,7 @@ mod tests {
                                 capacity_msat: 200_000,
                                 non_general_slots: 100,
                                 outgoing_reputation: 150,
-                                bidirectional_revenue: 600,
+                                incoming_revenue: 600,
                                 incoming_liquidity_utilization: 0.0,
                                 incoming_slot_utilization: 0.0,
                             },
@@ -319,7 +319,7 @@ mod tests {
                                 capacity_msat: 200_000,
                                 non_general_slots: 100,
                                 outgoing_reputation: 200,
-                                bidirectional_revenue: 250,
+                                incoming_revenue: 250,
                                 incoming_liquidity_utilization: 0.0,
                                 incoming_slot_utilization: 0.0,
                             },
@@ -333,7 +333,7 @@ mod tests {
                                 capacity_msat: 200_000,
                                 non_general_slots: 100,
                                 outgoing_reputation: 1000,
-                                bidirectional_revenue: 50,
+                                incoming_revenue: 50,
                                 incoming_liquidity_utilization: 0.0,
                                 incoming_slot_utilization: 0.0,
                             },
@@ -344,7 +344,7 @@ mod tests {
                                 capacity_msat: 200_000,
                                 non_general_slots: 100,
                                 outgoing_reputation: 350,
-                                bidirectional_revenue: 800,
+                                incoming_revenue: 800,
                                 incoming_liquidity_utilization: 0.0,
                                 incoming_slot_utilization: 0.0,
                             },
@@ -357,7 +357,7 @@ mod tests {
                             capacity_msat: 200_000,
                             non_general_slots: 100,
                             outgoing_reputation: 1000,
-                            bidirectional_revenue: 50,
+                            incoming_revenue: 50,
                             incoming_liquidity_utilization: 0.0,
                             incoming_slot_utilization: 0.0,
                         },

--- a/ln-simln-jamming/src/lib.rs
+++ b/ln-simln-jamming/src/lib.rs
@@ -194,24 +194,33 @@ mod tests {
                 0,
                 ChannelSnapshot {
                     capacity_msat: 200_000,
+                    non_general_slots: 100,
                     outgoing_reputation: 100_000,
                     bidirectional_revenue: 20_000,
+                    incoming_liquidity_utilization: 0.0,
+                    incoming_slot_utilization: 0.0,
                 },
             ),
             (
                 1,
                 ChannelSnapshot {
                     capacity_msat: 200_000,
+                    non_general_slots: 100,
                     outgoing_reputation: 45_000,
                     bidirectional_revenue: 50_000,
+                    incoming_liquidity_utilization: 0.0,
+                    incoming_slot_utilization: 0.0,
                 },
             ),
             (
                 2,
                 ChannelSnapshot {
                     capacity_msat: 200_000,
+                    non_general_slots: 100,
                     outgoing_reputation: 15_000,
                     bidirectional_revenue: 80_000,
+                    incoming_liquidity_utilization: 0.0,
+                    incoming_slot_utilization: 0.0,
                 },
             ),
         ]
@@ -264,32 +273,44 @@ mod tests {
                             0,
                             ChannelSnapshot {
                                 capacity_msat: 200_000,
+                                non_general_slots: 100,
                                 outgoing_reputation: 100,
                                 bidirectional_revenue: 15,
+                                incoming_liquidity_utilization: 0.0,
+                                incoming_slot_utilization: 0.0,
                             },
                         ),
                         (
                             1,
                             ChannelSnapshot {
                                 capacity_msat: 200_000,
+                                non_general_slots: 100,
                                 outgoing_reputation: 150,
                                 bidirectional_revenue: 110,
+                                incoming_liquidity_utilization: 0.0,
+                                incoming_slot_utilization: 0.0,
                             },
                         ),
                         (
                             2,
                             ChannelSnapshot {
                                 capacity_msat: 200_000,
+                                non_general_slots: 100,
                                 outgoing_reputation: 200,
                                 bidirectional_revenue: 90,
+                                incoming_liquidity_utilization: 0.0,
+                                incoming_slot_utilization: 0.0,
                             },
                         ),
                         (
                             3,
                             ChannelSnapshot {
                                 capacity_msat: 200_000,
+                                non_general_slots: 100,
                                 outgoing_reputation: 75,
                                 bidirectional_revenue: 100,
+                                incoming_liquidity_utilization: 0.0,
+                                incoming_slot_utilization: 0.0,
                             },
                         ),
                     ]
@@ -299,24 +320,33 @@ mod tests {
                             1,
                             ChannelSnapshot {
                                 capacity_msat: 200_000,
+                                non_general_slots: 100,
                                 outgoing_reputation: 500,
                                 bidirectional_revenue: 15,
+                                incoming_liquidity_utilization: 0.0,
+                                incoming_slot_utilization: 0.0,
                             },
                         ),
                         (
                             4,
                             ChannelSnapshot {
                                 capacity_msat: 200_000,
+                                non_general_slots: 100,
                                 outgoing_reputation: 150,
                                 bidirectional_revenue: 600,
+                                incoming_liquidity_utilization: 0.0,
+                                incoming_slot_utilization: 0.0,
                             },
                         ),
                         (
                             5,
                             ChannelSnapshot {
                                 capacity_msat: 200_000,
+                                non_general_slots: 100,
                                 outgoing_reputation: 200,
                                 bidirectional_revenue: 250,
+                                incoming_liquidity_utilization: 0.0,
+                                incoming_slot_utilization: 0.0,
                             },
                         ),
                     ]
@@ -326,16 +356,22 @@ mod tests {
                             2,
                             ChannelSnapshot {
                                 capacity_msat: 200_000,
+                                non_general_slots: 100,
                                 outgoing_reputation: 1000,
                                 bidirectional_revenue: 50,
+                                incoming_liquidity_utilization: 0.0,
+                                incoming_slot_utilization: 0.0,
                             },
                         ),
                         (
                             6,
                             ChannelSnapshot {
                                 capacity_msat: 200_000,
+                                non_general_slots: 100,
                                 outgoing_reputation: 350,
                                 bidirectional_revenue: 800,
+                                incoming_liquidity_utilization: 0.0,
+                                incoming_slot_utilization: 0.0,
                             },
                         ),
                     ]
@@ -344,8 +380,11 @@ mod tests {
                         3,
                         ChannelSnapshot {
                             capacity_msat: 200_000,
+                            non_general_slots: 100,
                             outgoing_reputation: 1000,
                             bidirectional_revenue: 50,
+                            incoming_liquidity_utilization: 0.0,
+                            incoming_slot_utilization: 0.0,
                         },
                     )]
                 } else {

--- a/ln-simln-jamming/src/main.rs
+++ b/ln-simln-jamming/src/main.rs
@@ -142,6 +142,7 @@ async fn main() -> Result<(), BoxError> {
             } else {
                 HashSet::from_iter(attacker_pubkeys.clone())
             },
+            now,
             clock.clone(),
             Some(results_writer),
         )

--- a/ln-simln-jamming/src/main.rs
+++ b/ln-simln-jamming/src/main.rs
@@ -174,10 +174,12 @@ async fn main() -> Result<(), BoxError> {
     // Reputation is assessed for a channel pair and a specific HTLC that's being proposed. To assess whether pairs
     // have reputation, we'll use LND's default fee policy to get the HTLC risk for our configured htlc size and hold
     // time.
-    let risk_margin = forward_params.htlc_opportunity_cost(
-        1000 + (0.0001 * cli.reputation_margin_msat as f64) as u64,
-        cli.reputation_margin_expiry_blocks,
-    );
+    let risk_margin = forward_params
+        .reputation_params
+        .opportunity_cost_from_blocks(
+            1000 + (0.0001 * cli.reputation_margin_msat as f64) as u64,
+            cli.reputation_margin_expiry_blocks,
+        );
 
     // Next, setup the attack interceptor to use our custom attack.
     let attack = setup_attack(

--- a/ln-simln-jamming/src/parsing.rs
+++ b/ln-simln-jamming/src/parsing.rs
@@ -317,13 +317,16 @@ pub enum AttackType {
     // NOTE: add your attack that you want to run here.
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn setup_attack<R, M>(
     cli: &Cli,
     simulation: &SimulationFiles,
     clock: Arc<SimulationClock>,
     reputation_monitor: Arc<R>,
     revenue_monitor: Arc<M>,
-    risk_margin: u64,
+    margin_blocks: u32,
+    margin_msat: u64,
+    reputation_params: ln_resource_mgr::ReputationParams,
 ) -> Result<Arc<dyn JammingAttack + Send + Sync>, BoxError>
 where
     R: ReputationMonitor + Send + Sync + 'static,
@@ -342,9 +345,11 @@ where
                 &sim_network,
                 simulation.target.1,
                 attacker_pubkeys,
-                risk_margin,
+                margin_blocks,
+                margin_msat,
                 reputation_monitor,
                 revenue_monitor,
+                reputation_params,
             ));
 
             Ok(attack)

--- a/ln-simln-jamming/src/parsing.rs
+++ b/ln-simln-jamming/src/parsing.rs
@@ -562,15 +562,21 @@ pub fn reputation_snapshot_from_file(
         let pubkey = PublicKey::from_slice(&hex::decode(&record[0])?)?;
         let scid: u64 = record[1].parse()?;
         let capacity_msat: u64 = record[2].parse()?;
-        let outgoing_reputation: i64 = record[3].parse()?;
-        let bidirectional_revenue: i64 = record[4].parse()?;
+        let non_general_slots: u16 = record[3].parse()?;
+        let outgoing_reputation: i64 = record[4].parse()?;
+        let bidirectional_revenue: i64 = record[5].parse()?;
+        let incoming_slot_utilization: f64 = record[6].parse()?;
+        let incoming_liquidity_utilization: f64 = record[7].parse()?;
 
         reputation_snapshot.entry(pubkey).or_default().insert(
             scid,
             ChannelSnapshot {
                 capacity_msat,
+                non_general_slots,
                 outgoing_reputation,
                 bidirectional_revenue,
+                incoming_slot_utilization,
+                incoming_liquidity_utilization,
             },
         );
     }

--- a/ln-simln-jamming/src/parsing.rs
+++ b/ln-simln-jamming/src/parsing.rs
@@ -569,7 +569,7 @@ pub fn reputation_snapshot_from_file(
         let capacity_msat: u64 = record[2].parse()?;
         let non_general_slots: u16 = record[3].parse()?;
         let outgoing_reputation: i64 = record[4].parse()?;
-        let bidirectional_revenue: i64 = record[5].parse()?;
+        let incoming_revenue: i64 = record[5].parse()?;
         let incoming_slot_utilization: f64 = record[6].parse()?;
         let incoming_liquidity_utilization: f64 = record[7].parse()?;
 
@@ -579,7 +579,7 @@ pub fn reputation_snapshot_from_file(
                 capacity_msat,
                 non_general_slots,
                 outgoing_reputation,
-                bidirectional_revenue,
+                incoming_revenue,
                 incoming_slot_utilization,
                 incoming_liquidity_utilization,
             },

--- a/ln-simln-jamming/src/reputation_interceptor.rs
+++ b/ln-simln-jamming/src/reputation_interceptor.rs
@@ -622,7 +622,7 @@ mod tests {
     };
     use ln_resource_mgr::{
         AccountableSignal, AllocationCheck, ChannelSnapshot, ForwardResolution, ForwardingOutcome,
-        HtlcRef, ProposedForward, ReputationError, ReputationManager, ReputationParams,
+        HtlcRef, ProposedForward, ReputationError, ReputationManager,
     };
     use mockall::mock;
     use sim_cli::parsing::NetworkParser;
@@ -631,7 +631,7 @@ mod tests {
     use simln_lib::ShortChannelID;
     use std::collections::{HashMap, HashSet};
     use std::sync::Arc;
-    use std::time::{Duration, Instant};
+    use std::time::Instant;
     use tokio::sync::Mutex;
 
     use crate::analysis::BatchForwardWriter;
@@ -923,19 +923,7 @@ mod tests {
         let alice_bob = ShortChannelID::from(1);
         let bob_carol = ShortChannelID::from(2);
 
-        let params = ForwardManagerParams {
-            reputation_params: ReputationParams {
-                revenue_window: Duration::from_secs(60),
-                reputation_multiplier: 60,
-                resolution_period: Duration::from_secs(90),
-                expected_block_speed: None,
-            },
-            general_slot_portion: 30,
-            general_liquidity_portion: 30,
-            congestion_slot_portion: 20,
-            congestion_liquidity_portion: 20,
-        };
-
+        let params = ForwardManagerParams::default();
         let edges = vec![
             setup_test_edge(alice_bob, alice, bob),
             setup_test_edge(bob_carol, bob, carol),

--- a/ln-simln-jamming/src/reputation_interceptor.rs
+++ b/ln-simln-jamming/src/reputation_interceptor.rs
@@ -935,7 +935,7 @@ mod tests {
                 capacity_msat: edge.capacity_msat,
                 non_general_slots: 337, // 70% of slots.
                 outgoing_reputation: 0,
-                bidirectional_revenue: 0,
+                incoming_revenue: 0,
                 incoming_liquidity_utilization: 0.1,
                 incoming_slot_utilization: 0.5,
             };
@@ -943,7 +943,7 @@ mod tests {
                 capacity_msat: edge.capacity_msat,
                 non_general_slots: 337, // 70% of slots.
                 outgoing_reputation: 0,
-                bidirectional_revenue: 0,
+                incoming_revenue: 0,
                 incoming_liquidity_utilization: 0.0,
                 incoming_slot_utilization: 0.0,
             };
@@ -1051,13 +1051,7 @@ mod tests {
             .list_channels(Instant::now())
             .unwrap();
 
-        assert!(
-            bob_reputation
-                .get(&alice_to_bob)
-                .unwrap()
-                .bidirectional_revenue
-                != 0
-        );
+        assert!(bob_reputation.get(&alice_to_bob).unwrap().incoming_revenue != 0);
         assert!(
             bob_reputation
                 .get(&bob_to_carol)
@@ -1186,7 +1180,7 @@ mod tests {
             capacity_msat: edge.capacity_msat,
             non_general_slots: 100,
             outgoing_reputation: 0,
-            bidirectional_revenue: 0,
+            incoming_revenue: 0,
             incoming_liquidity_utilization: 0.0,
             incoming_slot_utilization: 0.0,
         };

--- a/ln-simln-jamming/src/reputation_interceptor.rs
+++ b/ln-simln-jamming/src/reputation_interceptor.rs
@@ -948,8 +948,8 @@ mod tests {
                 non_general_slots: 337, // 70% of slots.
                 outgoing_reputation: 0,
                 bidirectional_revenue: 0,
-                incoming_liquidity_utilization: 0.0,
-                incoming_slot_utilization: 0.0,
+                incoming_liquidity_utilization: 0.1,
+                incoming_slot_utilization: 0.5,
             };
             let node_2_snapshot = ChannelSnapshot {
                 capacity_msat: edge.capacity_msat,

--- a/ln-simln-jamming/src/reputation_interceptor.rs
+++ b/ln-simln-jamming/src/reputation_interceptor.rs
@@ -944,13 +944,19 @@ mod tests {
         for edge in &edges {
             let node_1_snapshot = ChannelSnapshot {
                 capacity_msat: edge.capacity_msat,
+                non_general_slots: 337, // 70% of slots.
                 outgoing_reputation: 0,
                 bidirectional_revenue: 0,
+                incoming_liquidity_utilization: 0.0,
+                incoming_slot_utilization: 0.0,
             };
             let node_2_snapshot = ChannelSnapshot {
                 capacity_msat: edge.capacity_msat,
+                non_general_slots: 337, // 70% of slots.
                 outgoing_reputation: 0,
                 bidirectional_revenue: 0,
+                incoming_liquidity_utilization: 0.0,
+                incoming_slot_utilization: 0.0,
             };
 
             reputation_snapshot
@@ -1196,8 +1202,11 @@ mod tests {
         let edge = &edges[0];
         let node_1_snapshot = ChannelSnapshot {
             capacity_msat: edge.capacity_msat,
+            non_general_slots: 100,
             outgoing_reputation: 0,
             bidirectional_revenue: 0,
+            incoming_liquidity_utilization: 0.0,
+            incoming_slot_utilization: 0.0,
         };
         reputation_snapshot
             .entry(edge.node_1.pubkey)


### PR DESCRIPTION
Based this on #103 so that I don't have to solve a bunch of conflicts to rebase it. Also opening up early / same may-be-messy warnings apply.

---

In my investigations into reputation, it also seems like nodes are struggling to build reputation relative to the bidirectional revenue we were tracking. This PR updates the simulator to *only attribute successful forwards to the incoming channel's revenue*.

This follows, as we're defending against jamming in the outgoing direction - what we have to lose is all of our _incoming_ traffic. Doing this bi-directionally is an artifact of an older solution (when we were considering bi-di reputation).

This idea probably needs some thinking through, but it does get us to a simulator that's usable because we can get networks that actually have reputation.