### PR TITLE
Only track revenue threshold in one direction

### DIFF
--- a/ln-resource-mgr/src/forward_manager.rs
+++ b/ln-resource-mgr/src/forward_manager.rs
@@ -1,4 +1,3 @@
-use crate::decaying_average::DecayingAverage;
 use crate::htlc_manager::{ChannelFilter, InFlightHtlc, InFlightManager};
 use crate::incoming_channel::{BucketParameters, IncomingChannel};
 use crate::outgoing_channel::OutgoingChannel;
@@ -18,93 +17,6 @@ struct TrackedChannel {
     capacity_msat: u64,
     outgoing_direction: OutgoingChannel,
     incoming_direction: IncomingChannel,
-    revenue: RevenueAverage,
-}
-
-/// Tracks the average bi-directional revenue of a channel over multiple windows of time to smooth out this value over
-/// time. The number of windows that this average is tracked over is determined by [`Self::window_count`].
-///
-/// For example: if we're interested in tracking revenue over two weeks and we're interested in aggregating over ten
-/// windows, we will track the aggregate revenue over the last ten two week windows.
-#[derive(Debug)]
-struct RevenueAverage {
-    /// Tracks when the average started to be tracked. Used to track the actual number of windows we've been tracking
-    /// for when we haven't yet reached the full [`Self::window_count`]. This gives us some robustness on startup,
-    /// rather than underestimating.
-    ///
-    /// For example: if we've only been tracking for two windows of time, and we're averaging over ten windows we only
-    /// want to average across the two tracked windows (rather than averaging over ten and including eight windows that
-    /// are effectively zero).
-    start_ins: Instant,
-    /// The number of windows that we want to track our average revenue.
-    window_count: u8,
-    /// The length of the window we're tracking average values for.
-    window_duration: Duration,
-    /// Tracks the channel's average bi-directional revenue over the full period of time that we're interested in
-    /// aggregating. This is a decent approximation of tracking each window separately, and saves us needing to store
-    /// multiple data points per channel.
-    ///
-    /// For example:
-    /// - 2 week revenue period
-    /// - 12 window_count
-    ///
-    /// [`Self::aggregated_revenue_decaying`] will track average revenue over 24 weeks. The two week revenue window
-    /// revenue average can then be obtained by adjusting for the window side, which has the effect of evenly
-    /// distributing revenue between the windows.
-    aggregated_revenue_decaying: DecayingAverage,
-}
-
-impl RevenueAverage {
-    fn new(params: &ReputationParams, start_ins: Instant) -> Self {
-        RevenueAverage {
-            start_ins,
-            window_count: params.reputation_multiplier,
-            window_duration: params.revenue_window,
-            aggregated_revenue_decaying: DecayingAverage::new(
-                params.revenue_window * params.reputation_multiplier.into(),
-            ),
-        }
-    }
-
-    /// Decays the tracked value to its value at the instant provided and returns the updated value. The access_instant
-    /// must be after the last_updated time of the decaying average, tolerant to nanosecond differences.
-    fn add_value(&mut self, value: i64, update_time: Instant) -> Result<i64, ReputationError> {
-        self.aggregated_revenue_decaying
-            .add_value(value, update_time)
-    }
-
-    /// The number of full windows that have been tracked since the average started. Returned as a float so that the
-    /// average can be gradually scaled.
-    fn windows_tracked(&self, access_ins: Instant) -> f64 {
-        access_ins.duration_since(self.start_ins).as_secs_f64() / self.window_duration.as_secs_f64()
-    }
-
-    /// Updates the current value of the decaying average and then adds the new value provided. The value provided
-    /// will act as a saturating add if it exceeds i64::MAX.
-    fn value_at_instant(&mut self, access_ins: Instant) -> Result<i64, ReputationError> {
-        // If we're below our count of windows, we only want to aggregate for the amount of windows we've tracked so
-        // far. If we've reached out count, we just use that because the average only tracks this number of windows.
-        let windows_tracked = self.windows_tracked(access_ins);
-        let window_divisor = f64::min(
-            // If less than one window has been tracked, this will be a fraction which will inflate our revenue so we
-            // just flatten it to 1.
-            // TODO: better strategy for first window?
-            if windows_tracked < 1.0 {
-                1.0
-            } else {
-                windows_tracked
-            },
-            self.window_count as f64,
-        );
-
-        // To give the value for this longer-running average over an equivalent two week period, we just divide it by
-        // the number of windows we're counting.
-        Ok((self
-            .aggregated_revenue_decaying
-            .value_at_instant(access_ins)? as f64
-            / window_divisor)
-            .round() as i64)
-    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -187,6 +99,7 @@ impl ForwardManagerImpl {
             ))?;
 
         let incoming_revenue_threshold = incoming_channel
+            .incoming_direction
             .revenue
             .value_at_instant(forward.added_at)?;
 
@@ -351,26 +264,19 @@ impl ReputationManager for ForwardManager {
                     .as_ref()
                     .map(|channel| (channel.outgoing_reputation, add_ins));
 
-                let revenue = match &channel_reputation {
-                    Some(channel) => {
-                        if channel.capacity_msat != capacity_msat {
-                            return Err(ReputationError::ErrChannelCapacityMismatch(
-                                capacity_msat,
-                                channel.capacity_msat,
-                            ));
-                        }
-
-                        let mut revenue =
-                            RevenueAverage::new(&self.params.reputation_params, add_ins);
-                        revenue.add_value(channel.incoming_revenue, add_ins)?;
-                        revenue
+                if let Some(ref channel) = channel_reputation {
+                    if channel.capacity_msat != capacity_msat {
+                        return Err(ReputationError::ErrChannelCapacityMismatch(
+                            capacity_msat,
+                            channel.capacity_msat,
+                        ));
                     }
-                    None => RevenueAverage::new(&self.params.reputation_params, add_ins),
-                };
+                }
 
                 v.insert(TrackedChannel {
                     capacity_msat,
                     incoming_direction: IncomingChannel::new(
+                        &self.params.reputation_params,
                         channel_id,
                         BucketParameters {
                             slot_count: general_slot_count,
@@ -384,12 +290,13 @@ impl ReputationManager for ForwardManager {
                             slot_count: protected_slot_count,
                             liquidity_msat: protected_liquidity_amount,
                         },
+                        add_ins,
+                        channel_reputation.map(|snapshot| (snapshot.incoming_revenue)),
                     )?,
                     outgoing_direction: OutgoingChannel::new(
                         self.params.reputation_params,
                         outgoing_reputation,
                     )?,
-                    revenue,
                 });
 
                 Ok(())
@@ -533,6 +440,7 @@ impl ReputationManager for ForwardManager {
             .channels
             .get_mut(&outgoing_channel)
             .ok_or(ReputationError::ErrOutgoingNotFound(outgoing_channel))?
+            .incoming_direction
             .revenue
             .add_value(fee_i64, resolved_instant)?;
 
@@ -542,6 +450,7 @@ impl ReputationManager for ForwardManager {
             .ok_or(ReputationError::ErrIncomingNotFound(
                 incoming_ref.channel_id,
             ))?
+            .incoming_direction
             .revenue
             .add_value(fee_i64, resolved_instant)?;
 
@@ -569,7 +478,10 @@ impl ReputationManager for ForwardManager {
                     outgoing_reputation: channel
                         .outgoing_direction
                         .outgoing_reputation(access_ins)?,
-                    incoming_revenue: channel.revenue.value_at_instant(access_ins)?,
+                    incoming_revenue: channel
+                        .incoming_direction
+                        .revenue
+                        .value_at_instant(access_ins)?,
                 },
             );
         }
@@ -582,7 +494,7 @@ impl ReputationManager for ForwardManager {
 mod tests {
     use std::time::{Duration, Instant};
 
-    use super::{ForwardManagerParams, RevenueAverage};
+    use super::ForwardManagerParams;
     use crate::{
         forward_manager::{ForwardManager, SimulationDebugManager},
         AccountableSignal, ChannelSnapshot, FailureReason, ForwardingOutcome, HtlcRef,
@@ -622,91 +534,6 @@ mod tests {
             .incoming_direction;
         assert!(channel_0.general_bucket.params.slot_count == 0);
         assert!(channel_0.congestion_bucket.slot_count == 0);
-    }
-
-    #[test]
-    fn test_revenue_average() {
-        let params = ReputationParams {
-            revenue_window: Duration::from_secs(60 * 60 * 24 * 14),
-            reputation_multiplier: 10,
-            resolution_period: Duration::from_secs(90),
-            expected_block_speed: None,
-        };
-
-        let now = Instant::now();
-        let mut revenue_average = RevenueAverage::new(&params, now);
-
-        assert_eq!(revenue_average.value_at_instant(now).unwrap(), 0);
-
-        let value = 10_000;
-
-        // When we're right at the beginning our our tracking, revenue shouldn't be divided over multiple periods,
-        // because we haven't tracked that long yet.
-        revenue_average.add_value(value, now).unwrap();
-        assert_eq!(revenue_average.value_at_instant(now).unwrap(), value);
-
-        // Progress our timestamp to the end of the first window of time. We're testing the division of total revenue
-        // tracked over windows, not the actual decaying average, so we peek under the hood to get the value that we've
-        // decayed to and then assert that
-        let end_first_window = now.checked_add(params.revenue_window).unwrap();
-        let decayed_value = revenue_average
-            .aggregated_revenue_decaying
-            .value_at_instant(end_first_window)
-            .unwrap();
-
-        assert_eq!(
-            revenue_average.value_at_instant(end_first_window).unwrap(),
-            decayed_value
-        );
-
-        // Move to half way through the second window, the value should now be split between two periods. Again, we'll
-        // peek under at the decayed value and then check that it's being split over periods.
-        let half_second_window = end_first_window
-            .checked_add(params.revenue_window / 2)
-            .unwrap();
-        let decayed_value = revenue_average
-            .aggregated_revenue_decaying
-            .value_at_instant(half_second_window)
-            .unwrap();
-
-        assert_eq!(
-            revenue_average
-                .value_at_instant(half_second_window)
-                .unwrap(),
-            (decayed_value as f64 / 1.5).round() as i64,
-        );
-
-        // Finally, test that once we reach our total window count, we don't continue to divide by more and more
-        // windows.
-        let final_window = now
-            .checked_add(params.revenue_window * params.reputation_multiplier.into())
-            .unwrap();
-        let decayed_value = revenue_average
-            .aggregated_revenue_decaying
-            .value_at_instant(final_window)
-            .unwrap();
-
-        assert_eq!(
-            revenue_average.value_at_instant(final_window).unwrap(),
-            (decayed_value as f64 / params.reputation_multiplier as f64).round() as i64,
-        );
-
-        // Once we get beyond the window count, it's just the decay at play and we're using the count to divide our
-        // running average.
-        let beyond_final_window = now
-            .checked_add(params.revenue_window * params.reputation_multiplier.into() * 5)
-            .unwrap();
-        let decayed_value = revenue_average
-            .aggregated_revenue_decaying
-            .value_at_instant(beyond_final_window)
-            .unwrap();
-
-        assert_eq!(
-            revenue_average
-                .value_at_instant(beyond_final_window)
-                .unwrap(),
-            (decayed_value as f64 / params.reputation_multiplier as f64).round() as i64,
-        );
     }
 
     fn test_forward_manager_params() -> ForwardManagerParams {

--- a/ln-resource-mgr/src/forward_manager.rs
+++ b/ln-resource-mgr/src/forward_manager.rs
@@ -433,17 +433,8 @@ impl ReputationManager for ForwardManager {
             return Ok(());
         }
 
-        // If the htlc was settled, update *both* the outgoing and incoming channel's revenue trackers.
+        // If the htlc was settled, update the incoming channel's revenue.
         let fee_i64 = i64::try_from(in_flight.fee_msat).unwrap_or(i64::MAX);
-
-        inner_lock
-            .channels
-            .get_mut(&outgoing_channel)
-            .ok_or(ReputationError::ErrOutgoingNotFound(outgoing_channel))?
-            .incoming_direction
-            .revenue
-            .add_value(fee_i64, resolved_instant)?;
-
         inner_lock
             .channels
             .get_mut(&incoming_ref.channel_id)

--- a/ln-resource-mgr/src/forward_manager.rs
+++ b/ln-resource-mgr/src/forward_manager.rs
@@ -362,7 +362,7 @@ impl ReputationManager for ForwardManager {
 
                         let mut revenue =
                             RevenueAverage::new(&self.params.reputation_params, add_ins);
-                        revenue.add_value(channel.bidirectional_revenue, add_ins)?;
+                        revenue.add_value(channel.incoming_revenue, add_ins)?;
                         revenue
                     }
                     None => RevenueAverage::new(&self.params.reputation_params, add_ins),
@@ -569,7 +569,7 @@ impl ReputationManager for ForwardManager {
                     outgoing_reputation: channel
                         .outgoing_direction
                         .outgoing_reputation(access_ins)?,
-                    bidirectional_revenue: channel.revenue.value_at_instant(access_ins)?,
+                    incoming_revenue: channel.revenue.value_at_instant(access_ins)?,
                 },
             );
         }
@@ -740,7 +740,7 @@ mod tests {
         let snapshot = ChannelSnapshot {
             capacity_msat: 10_000_000,
             outgoing_reputation: 1000,
-            bidirectional_revenue: 500,
+            incoming_revenue: 500,
         };
         assert!(fwd_manager
             .add_channel(1, channel_capacity, now, Some(snapshot.clone()))
@@ -768,7 +768,7 @@ mod tests {
         // Check values on 2nd channel added from snapshot
         assert!(channels.get(&1).unwrap().capacity_msat == channel_capacity);
         assert!(channels.get(&1).unwrap().outgoing_reputation == 1000);
-        assert!(channels.get(&1).unwrap().bidirectional_revenue == 500);
+        assert!(channels.get(&1).unwrap().incoming_revenue == 500);
 
         assert!(fwd_manager.remove_channel(0).is_ok());
         assert!(
@@ -837,7 +837,7 @@ mod tests {
         let snapshot = ChannelSnapshot {
             capacity_msat: channel_capacity,
             outgoing_reputation: 10_000_000,
-            bidirectional_revenue: 1_000_000,
+            incoming_revenue: 1_000_000,
         };
         let channel_with_reputation = 2;
 
@@ -886,7 +886,7 @@ mod tests {
         let snapshot = ChannelSnapshot {
             capacity_msat: channel_capacity,
             outgoing_reputation: 10_000_000,
-            bidirectional_revenue: 1_000_000,
+            incoming_revenue: 1_000_000,
         };
         let channel_with_reputation = 2;
 

--- a/ln-resource-mgr/src/lib.rs
+++ b/ln-resource-mgr/src/lib.rs
@@ -519,7 +519,7 @@ impl ProposedForward {
 pub struct ChannelSnapshot {
     pub capacity_msat: u64,
     pub outgoing_reputation: i64,
-    pub bidirectional_revenue: i64,
+    pub incoming_revenue: i64,
 }
 
 /// Validates that an msat amount doesn't exceed the total supply cap of bitcoin and casts to i64 to be used in

--- a/ln-simln-jamming/src/attacks/utils.rs
+++ b/ln-simln-jamming/src/attacks/utils.rs
@@ -106,7 +106,7 @@ pub async fn build_reputation<R: ReputationMonitor>(
     let current_target_revenue = channels
         .get(&target_channel.1)
         .ok_or(format!("target channel {} not found", target_channel.1))?
-        .bidirectional_revenue;
+        .incoming_revenue;
 
     let current_attacker_reputation = channels
         .get(&last_hop_channel)
@@ -169,7 +169,7 @@ pub async fn build_reputation<R: ReputationMonitor>(
     let target_revenue = channels
         .get(&target_channel.1)
         .ok_or(format!("target channel {} not found", target_channel.1))?
-        .bidirectional_revenue;
+        .incoming_revenue;
 
     let attacker_reputation = channels
         .get(&last_hop_channel)

--- a/ln-simln-jamming/src/bin/reputation_builder.rs
+++ b/ln-simln-jamming/src/bin/reputation_builder.rs
@@ -158,7 +158,7 @@ async fn main() -> Result<(), BoxError> {
         "scid",
         "channel_capacity",
         "outgoing_reputation",
-        "bidirectional_revenue",
+        "incoming_revenue",
     ])?;
 
     for pubkey in node_pubkeys {
@@ -172,7 +172,7 @@ async fn main() -> Result<(), BoxError> {
                 channel.0,
                 channel.1.capacity_msat,
                 channel.1.outgoing_reputation,
-                channel.1.bidirectional_revenue,
+                channel.1.incoming_revenue,
             ))?;
         }
     }

--- a/ln-simln-jamming/src/lib.rs
+++ b/ln-simln-jamming/src/lib.rs
@@ -136,7 +136,7 @@ fn count_reputation_pairs(
         .filter(|(scid, snapshot)| {
             **scid != outgoing_channel
                 && outgoing_channel_snapshot.outgoing_reputation
-                    >= snapshot.bidirectional_revenue + risk_margin as i64
+                    >= snapshot.incoming_revenue + risk_margin as i64
         })
         .count())
 }
@@ -195,7 +195,7 @@ mod tests {
                 ChannelSnapshot {
                     capacity_msat: 200_000,
                     outgoing_reputation: 100_000,
-                    bidirectional_revenue: 20_000,
+                    incoming_revenue: 20_000,
                 },
             ),
             (
@@ -203,7 +203,7 @@ mod tests {
                 ChannelSnapshot {
                     capacity_msat: 200_000,
                     outgoing_reputation: 45_000,
-                    bidirectional_revenue: 50_000,
+                    incoming_revenue: 50_000,
                 },
             ),
             (
@@ -211,7 +211,7 @@ mod tests {
                 ChannelSnapshot {
                     capacity_msat: 200_000,
                     outgoing_reputation: 15_000,
-                    bidirectional_revenue: 80_000,
+                    incoming_revenue: 80_000,
                 },
             ),
         ]
@@ -265,7 +265,7 @@ mod tests {
                             ChannelSnapshot {
                                 capacity_msat: 200_000,
                                 outgoing_reputation: 100,
-                                bidirectional_revenue: 15,
+                                incoming_revenue: 15,
                             },
                         ),
                         (
@@ -273,7 +273,7 @@ mod tests {
                             ChannelSnapshot {
                                 capacity_msat: 200_000,
                                 outgoing_reputation: 150,
-                                bidirectional_revenue: 110,
+                                incoming_revenue: 110,
                             },
                         ),
                         (
@@ -281,7 +281,7 @@ mod tests {
                             ChannelSnapshot {
                                 capacity_msat: 200_000,
                                 outgoing_reputation: 200,
-                                bidirectional_revenue: 90,
+                                incoming_revenue: 90,
                             },
                         ),
                         (
@@ -289,7 +289,7 @@ mod tests {
                             ChannelSnapshot {
                                 capacity_msat: 200_000,
                                 outgoing_reputation: 75,
-                                bidirectional_revenue: 100,
+                                incoming_revenue: 100,
                             },
                         ),
                     ]
@@ -300,7 +300,7 @@ mod tests {
                             ChannelSnapshot {
                                 capacity_msat: 200_000,
                                 outgoing_reputation: 500,
-                                bidirectional_revenue: 15,
+                                incoming_revenue: 15,
                             },
                         ),
                         (
@@ -308,7 +308,7 @@ mod tests {
                             ChannelSnapshot {
                                 capacity_msat: 200_000,
                                 outgoing_reputation: 150,
-                                bidirectional_revenue: 600,
+                                incoming_revenue: 600,
                             },
                         ),
                         (
@@ -316,7 +316,7 @@ mod tests {
                             ChannelSnapshot {
                                 capacity_msat: 200_000,
                                 outgoing_reputation: 200,
-                                bidirectional_revenue: 250,
+                                incoming_revenue: 250,
                             },
                         ),
                     ]
@@ -327,7 +327,7 @@ mod tests {
                             ChannelSnapshot {
                                 capacity_msat: 200_000,
                                 outgoing_reputation: 1000,
-                                bidirectional_revenue: 50,
+                                incoming_revenue: 50,
                             },
                         ),
                         (
@@ -335,7 +335,7 @@ mod tests {
                             ChannelSnapshot {
                                 capacity_msat: 200_000,
                                 outgoing_reputation: 350,
-                                bidirectional_revenue: 800,
+                                incoming_revenue: 800,
                             },
                         ),
                     ]
@@ -345,7 +345,7 @@ mod tests {
                         ChannelSnapshot {
                             capacity_msat: 200_000,
                             outgoing_reputation: 1000,
-                            bidirectional_revenue: 50,
+                            incoming_revenue: 50,
                         },
                     )]
                 } else {

--- a/ln-simln-jamming/src/parsing.rs
+++ b/ln-simln-jamming/src/parsing.rs
@@ -568,14 +568,14 @@ pub fn reputation_snapshot_from_file(
         let scid: u64 = record[1].parse()?;
         let capacity_msat: u64 = record[2].parse()?;
         let outgoing_reputation: i64 = record[3].parse()?;
-        let bidirectional_revenue: i64 = record[4].parse()?;
+        let incoming_revenue: i64 = record[4].parse()?;
 
         reputation_snapshot.entry(pubkey).or_default().insert(
             scid,
             ChannelSnapshot {
                 capacity_msat,
                 outgoing_reputation,
-                bidirectional_revenue,
+                incoming_revenue,
             },
         );
     }

--- a/ln-simln-jamming/src/reputation_interceptor.rs
+++ b/ln-simln-jamming/src/reputation_interceptor.rs
@@ -945,12 +945,12 @@ mod tests {
             let node_1_snapshot = ChannelSnapshot {
                 capacity_msat: edge.capacity_msat,
                 outgoing_reputation: 0,
-                bidirectional_revenue: 0,
+                incoming_revenue: 0,
             };
             let node_2_snapshot = ChannelSnapshot {
                 capacity_msat: edge.capacity_msat,
                 outgoing_reputation: 0,
-                bidirectional_revenue: 0,
+                incoming_revenue: 0,
             };
 
             reputation_snapshot
@@ -1065,13 +1065,7 @@ mod tests {
             .list_channels(Instant::now())
             .unwrap();
 
-        assert!(
-            bob_reputation
-                .get(&alice_to_bob)
-                .unwrap()
-                .bidirectional_revenue
-                != 0
-        );
+        assert!(bob_reputation.get(&alice_to_bob).unwrap().incoming_revenue != 0);
         assert!(
             bob_reputation
                 .get(&bob_to_carol)
@@ -1197,7 +1191,7 @@ mod tests {
         let node_1_snapshot = ChannelSnapshot {
             capacity_msat: edge.capacity_msat,
             outgoing_reputation: 0,
-            bidirectional_revenue: 0,
+            incoming_revenue: 0,
         };
         reputation_snapshot
             .entry(edge.node_1.pubkey)


### PR DESCRIPTION
Previously, we would add the revenue for a HTLC forward to both its incoming and outgoing channel's revenue target.
This PR updates tracking to only attribute HTLC fees to the revenue of the incoming channel that delivered it to our node.