### PR TITLE
Scale htlc risk by CLTV delta

### DIFF
--- a/ln-resource-mgr/src/forward_manager.rs
+++ b/ln-resource-mgr/src/forward_manager.rs
@@ -135,14 +135,6 @@ impl Default for ForwardManagerParams {
     }
 }
 
-impl ForwardManagerParams {
-    /// Returns the opportunity cost for the htlc amount and expiry provided, assuming 10 minute blocks.
-    pub fn htlc_opportunity_cost(&self, fee_msat: u64, expiry: u32) -> u64 {
-        self.reputation_params
-            .opportunity_cost(fee_msat, Duration::from_secs(expiry as u64 * 10 * 60))
-    }
-}
-
 /// Defines special actions that can be taken during a simulation that wouldn't otherwise be used in regular operation.
 pub trait SimulationDebugManager {
     fn general_jam_channel(&self, channel: u64) -> Result<(), ReputationError>;

--- a/ln-resource-mgr/src/forward_manager.rs
+++ b/ln-resource-mgr/src/forward_manager.rs
@@ -193,6 +193,7 @@ impl ForwardManagerImpl {
                 ),
                 htlc_risk: self
                     .htlcs
+                    .params
                     .htlc_risk(forward.fee_msat(), forward.expiry_in_height),
             },
             general_eligible: incoming_channel

--- a/ln-resource-mgr/src/htlc_manager.rs
+++ b/ln-resource-mgr/src/htlc_manager.rs
@@ -87,7 +87,7 @@ pub enum ChannelFilter {
 #[derive(Debug)]
 pub(super) struct InFlightManager {
     in_flight: HashMap<HtlcRef, InFlightHtlc>,
-    params: ReputationParams,
+    pub(super) params: ReputationParams,
 }
 
 impl InFlightManager {
@@ -183,11 +183,6 @@ impl InFlightManager {
             v.bucket == ResourceBucketType::Congestion
                 && v.outgoing_channel_id == outgoing_channel_id
         })
-    }
-
-    /// Calculates the worst case reputation damage of a htlc, assuming it'll be held for its full expiry_delta.
-    pub(super) fn htlc_risk(&self, fee_msat: u64, expiry_delta: u32) -> u64 {
-        self.params.htlc_risk(fee_msat, expiry_delta)
     }
 }
 

--- a/ln-resource-mgr/src/htlc_manager.rs
+++ b/ln-resource-mgr/src/htlc_manager.rs
@@ -36,7 +36,7 @@ impl ReputationParams {
     }
 
     /// Calculates the worst case reputation damage of a htlc, assuming it'll be held for its full expiry_delta.
-    pub(super) fn htlc_risk(&self, fee_msat: u64, expiry_delta: u32) -> u64 {
+    pub fn htlc_risk(&self, fee_msat: u64, expiry_delta: u32) -> u64 {
         let max_hold_time = self
             .expected_block_speed
             .unwrap_or_else(|| Duration::from_secs(60 * 10))

--- a/ln-resource-mgr/src/lib.rs
+++ b/ln-resource-mgr/src/lib.rs
@@ -545,6 +545,7 @@ pub trait ReputationManager {
         &self,
         channel_id: u64,
         capacity_msat: u64,
+        cltv_expiry_delta: u32,
         add_ins: Instant,
         channel_reputation: Option<ChannelSnapshot>,
     ) -> Result<(), ReputationError>;

--- a/ln-resource-mgr/src/outgoing_channel.rs
+++ b/ln-resource-mgr/src/outgoing_channel.rs
@@ -123,6 +123,7 @@ mod tests {
         InFlightHtlc {
             outgoing_channel_id: 1,
             hold_blocks: 1000,
+            cltv_expiry_delta: 100,
             incoming_amt_msat: 2000,
             fee_msat,
             added_instant: Instant::now(),

--- a/ln-simln-jamming/src/attacks/utils.rs
+++ b/ln-simln-jamming/src/attacks/utils.rs
@@ -219,7 +219,8 @@ fn fee_to_build_reputation(
 
                 let target_hop = &path.hops[target_idx];
                 let current_htlc_risk = forward_params
-                    .htlc_opportunity_cost(target_hop.fee_msat, cltv_expiry + CLTV_OFFSET_LDK);
+                    .reputation_params
+                    .htlc_risk(target_hop.fee_msat, cltv_expiry + CLTV_OFFSET_LDK);
 
                 total_htlc_risk += current_htlc_risk;
             }
@@ -348,7 +349,7 @@ mod tests {
         let htlc_risk = {
             let mut risk = 0;
             for htlc in htlc_amounts.iter() {
-                risk += fwd_params.htlc_opportunity_cost(
+                risk += fwd_params.reputation_params.htlc_risk(
                     (*htlc as f64 * fee_pct) as u64,
                     expiry_delta + CLTV_OFFSET_LDK,
                 );

--- a/ln-simln-jamming/src/lib.rs
+++ b/ln-simln-jamming/src/lib.rs
@@ -20,6 +20,9 @@ pub(crate) mod test_utils;
 /// Error type for errors that can be erased, includes 'static so that down-casting is possible.
 pub type BoxError = Box<dyn Error + Send + Sync + 'static>;
 
+/// The default CLTV delta that we assume for channels in the network.
+pub const DEFAULT_CLTV_DELTA: u32 = 80;
+
 /// The TLV type used to represent experimental accountable signals.
 pub const ACCOUNTABLE_TYPE: u64 = 106823;
 

--- a/ln-simln-jamming/src/main.rs
+++ b/ln-simln-jamming/src/main.rs
@@ -12,7 +12,8 @@ use ln_simln_jamming::revenue_interceptor::{
     PeacetimeRevenueMonitor, RevenueInterceptor, RevenueSnapshot,
 };
 use ln_simln_jamming::{
-    get_network_reputation, BoxError, NetworkReputation, ACCOUNTABLE_TYPE, UPGRADABLE_TYPE,
+    get_network_reputation, BoxError, NetworkReputation, ACCOUNTABLE_TYPE, DEFAULT_CLTV_DELTA,
+    UPGRADABLE_TYPE,
 };
 use log::LevelFilter;
 use sim_cli::parsing::{create_simulation_with_network, SimParams};
@@ -176,6 +177,7 @@ async fn main() -> Result<(), BoxError> {
     let risk_margin = forward_params.reputation_params.htlc_risk(
         1000 + (0.0001 * cli.reputation_margin_msat as f64) as u64,
         cli.reputation_margin_expiry_blocks,
+        DEFAULT_CLTV_DELTA,
     );
 
     // Next, setup the attack interceptor to use our custom attack.

--- a/ln-simln-jamming/src/main.rs
+++ b/ln-simln-jamming/src/main.rs
@@ -173,7 +173,7 @@ async fn main() -> Result<(), BoxError> {
     // Reputation is assessed for a channel pair and a specific HTLC that's being proposed. To assess whether pairs
     // have reputation, we'll use LND's default fee policy to get the HTLC risk for our configured htlc size and hold
     // time.
-    let risk_margin = forward_params.htlc_opportunity_cost(
+    let risk_margin = forward_params.reputation_params.htlc_risk(
         1000 + (0.0001 * cli.reputation_margin_msat as f64) as u64,
         cli.reputation_margin_expiry_blocks,
     );


### PR DESCRIPTION
We're struggling to get reputation because multiplying htlc fees by the total time it could be held by (cltv delta, assuming 10 minute blocks, expressed in seconds) is a very large number.

To capture the idea of a "reasonable" hold time, we divide hold time by our node's chosen CLTV delta. This allows us to increase risk as hold time increases, without having to have such large numbers.

The unfortunate implementation detail here is that we now have to have our CLTV delta handy, which is a bit of a hack. Opening early in draft, last commit could probably use some work. 