### PR TITLE
ln-simln-jamming/bugfix: pull history for full reputation period

### DIFF
--- a/ln-simln-jamming/src/bin/reputation_builder.rs
+++ b/ln-simln-jamming/src/bin/reputation_builder.rs
@@ -66,7 +66,7 @@ async fn main() -> Result<(), BoxError> {
 
     let unfiltered_history = history_from_file(
         traffic_file,
-        Some(forward_params.reputation_params.revenue_window),
+        Some(forward_params.reputation_params.reputation_window()),
     )
     .await?;
 


### PR DESCRIPTION
We should be pulling our history for the full reputation-building period so that peers can build reputation properly.