### PR TITLE
Misc improvements to reporting

### DIFF
--- a/ln-simln-jamming/src/attacks/sink.rs
+++ b/ln-simln-jamming/src/attacks/sink.rs
@@ -287,6 +287,12 @@ where
                     )
                     .await?;
 
+                    log::debug!("Attacker has good reputation with target for: {}/{} pairs",
+                        current_reputation.attacker_reputation, current_reputation.attacker_pair_count);
+
+                    log::debug!("Target has good reputation with peers for: {}/{} pairs",
+                        current_reputation.target_reputation, current_reputation.target_pair_count);
+
                     if inner_simulation_completed(&start_reputation, &current_reputation)? {
                         return Ok(())
                     }

--- a/ln-simln-jamming/src/bin/reputation_builder.rs
+++ b/ln-simln-jamming/src/bin/reputation_builder.rs
@@ -140,9 +140,10 @@ async fn main() -> Result<(), BoxError> {
         node_pubkeys.insert(chan.node_2.pubkey);
     }
 
-    let (reputation_state, target_revenue) = network_dir.reputation_summary(cli.attacker_bootstrap);
+    let (reputation_state, target_revenue_path) =
+        network_dir.reputation_summary(cli.attacker_bootstrap);
 
-    let mut target_revenue = File::create(target_revenue)?;
+    let mut target_revenue = File::create(target_revenue_path.clone())?;
     write!(target_revenue, "{}", bootstrap_revenue)?;
 
     let snapshot_file = OpenOptions::new()
@@ -178,9 +179,9 @@ async fn main() -> Result<(), BoxError> {
     csv_writer.flush()?;
 
     log::info!(
-        "Finished writing reputation snapshot to {:?} and {:?}",
+        "Finished writing reputation snapshot to {:?} and revenue to {:?}",
         reputation_state,
-        target_revenue
+        target_revenue_path,
     );
 
     Ok(())

--- a/ln-simln-jamming/src/main.rs
+++ b/ln-simln-jamming/src/main.rs
@@ -84,7 +84,7 @@ async fn main() -> Result<(), BoxError> {
     let now = InstantClock::now(&*clock);
 
     // Create a writer to store results for nodes that we care about.
-    let results_dir = network_dir.results_dir();
+    let results_dir = network_dir.results_dir(Clock::now(&*clock))?;
     let mut monitor_channels: Vec<(PublicKey, String)> =
         target_channels.values().cloned().collect();
     monitor_channels.push((target_pubkey, network_dir.target.0.clone()));

--- a/ln-simln-jamming/src/main.rs
+++ b/ln-simln-jamming/src/main.rs
@@ -364,8 +364,9 @@ fn write_simulation_summary(
     general_jammed: usize,
 ) -> Result<(), BoxError> {
     let file = OpenOptions::new()
-        .append(true)
+        .write(true)
         .create(true)
+        .truncate(true)
         .open(data_dir.join("summary.txt"))?;
 
     let mut writer = BufWriter::new(file);


### PR DESCRIPTION
Various minor improvements to how we report information:
* Log reputation standings during sink attack
* Write results to timestamped sub-directories so they don't overwrite each other
* Improve logging of file locations in reputation builder