### PR TITLE
trivial: renames and data adjustments

### DIFF
--- a/ln-simln-jamming/src/analysis.rs
+++ b/ln-simln-jamming/src/analysis.rs
@@ -36,7 +36,7 @@ impl Serialize for Record {
     where
         S: Serializer,
     {
-        let mut state = serializer.serialize_struct("Record", 15)?;
+        let mut state = serializer.serialize_struct("Record", 20)?;
         state.serialize_field(
             "ts_offset_ns",
             &self
@@ -82,15 +82,47 @@ impl Serialize for Record {
             &self.decision.reputation_check.in_flight_total_risk,
         )?;
         state.serialize_field(
-            "slots_available",
+            "general_slots_available",
             &self.decision.resource_check.general_bucket.slots_available,
         )?;
         state.serialize_field(
-            "liquidity_available",
+            "general_liquidity_available",
             &self
                 .decision
                 .resource_check
                 .general_bucket
+                .liquidity_available_msat,
+        )?;
+        state.serialize_field(
+            "congestion_slots_available",
+            &self
+                .decision
+                .resource_check
+                .congestion_bucket
+                .slots_available,
+        )?;
+        state.serialize_field(
+            "congestion_liquidity_available",
+            &self
+                .decision
+                .resource_check
+                .congestion_bucket
+                .liquidity_available_msat,
+        )?;
+        state.serialize_field(
+            "protected_slots_available",
+            &self
+                .decision
+                .resource_check
+                .protected_bucket
+                .slots_available,
+        )?;
+        state.serialize_field(
+            "protected_liquidity_available",
+            &self
+                .decision
+                .resource_check
+                .protected_bucket
                 .liquidity_available_msat,
         )?;
         state.end()

--- a/ln-simln-jamming/src/main.rs
+++ b/ln-simln-jamming/src/main.rs
@@ -308,6 +308,7 @@ async fn main() -> Result<(), BoxError> {
 
     let snapshot = revenue_interceptor.get_revenue_difference().await;
     write_simulation_summary(
+        &cli,
         results_dir,
         &snapshot,
         &start_reputation,
@@ -357,6 +358,7 @@ fn check_reputation_status(cli: &Cli, status: &NetworkReputation) -> Result<(), 
 
 #[allow(clippy::too_many_arguments)]
 fn write_simulation_summary(
+    cli: &Cli,
     data_dir: PathBuf,
     revenue: &RevenueSnapshot,
     start_reputation: &NetworkReputation,
@@ -396,7 +398,11 @@ fn write_simulation_summary(
             revenue.peacetime_revenue_msat - revenue.simulation_revenue_msat,
         )?;
     }
-
+    writeln!(
+        writer,
+        "Attacker bootstrapped reputation for: {} seconds",
+        cli.attacker_bootstrap.unwrap_or(Duration::ZERO).as_secs(),
+    )?;
     writeln!(
         writer,
         "Attacker start reputation (pairs): {}/{}",

--- a/ln-simln-jamming/src/parsing.rs
+++ b/ln-simln-jamming/src/parsing.rs
@@ -171,7 +171,7 @@ impl SimulationFiles {
         let reputation_dir = self
             .dir
             .join("reputation")
-            .join(HumanDuration::from(duration.unwrap_or(Duration::ZERO)).to_string());
+            .join(duration.unwrap_or(Duration::ZERO).as_secs().to_string());
 
         // Create the specific duration directory
         let _ = std::fs::create_dir_all(&reputation_dir);


### PR DESCRIPTION
* Rename reputation sub-dirs to just be expressed in seconds, because humantime led to values like "5 months 7 days and 1 minute"
* Include all buckets liquidity / slots reporting in data output per node
* Write bootstrap period to simulation summary