### PR TITLE
ln-simln-jamming: bump sim-ln dependency to include exclude fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2500,7 +2500,7 @@ dependencies = [
 [[package]]
 name = "sim-cli"
 version = "0.1.1"
-source = "git+https://github.com/bitcoin-dev-project/sim-ln?rev=2bdd675c7484c1d7491b095ae62cb7597514d7b6#2bdd675c7484c1d7491b095ae62cb7597514d7b6"
+source = "git+https://github.com/bitcoin-dev-project/sim-ln?rev=ec1aa36210d3ee5c67ed56363602b09c4978153d#ec1aa36210d3ee5c67ed56363602b09c4978153d"
 dependencies = [
  "anyhow",
  "bitcoin 0.30.2",
@@ -2524,7 +2524,7 @@ dependencies = [
 [[package]]
 name = "simln-lib"
 version = "0.1.1"
-source = "git+https://github.com/bitcoin-dev-project/sim-ln?rev=2bdd675c7484c1d7491b095ae62cb7597514d7b6#2bdd675c7484c1d7491b095ae62cb7597514d7b6"
+source = "git+https://github.com/bitcoin-dev-project/sim-ln?rev=ec1aa36210d3ee5c67ed56363602b09c4978153d#ec1aa36210d3ee5c67ed56363602b09c4978153d"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/ln-simln-jamming/Cargo.toml
+++ b/ln-simln-jamming/Cargo.toml
@@ -12,8 +12,8 @@ name = "forward-builder"
 path = "src/bin/forward_builder.rs"
 
 [dependencies]
-simln-lib = { git = "https://github.com/bitcoin-dev-project/sim-ln", rev = "2bdd675c7484c1d7491b095ae62cb7597514d7b6" }
-sim-cli = { git = "https://github.com/bitcoin-dev-project/sim-ln", rev = "2bdd675c7484c1d7491b095ae62cb7597514d7b6" }
+simln-lib = { git = "https://github.com/bitcoin-dev-project/sim-ln", rev = "ec1aa36210d3ee5c67ed56363602b09c4978153d" }
+sim-cli = { git = "https://github.com/bitcoin-dev-project/sim-ln", rev = "ec1aa36210d3ee5c67ed56363602b09c4978153d" }
 ln-resource-mgr = { path = "../ln-resource-mgr" }
 bitcoin = { version = "0.30.1" }
 async-trait = "0.1.73"

--- a/ln-simln-jamming/src/attacks/utils.rs
+++ b/ln-simln-jamming/src/attacks/utils.rs
@@ -440,7 +440,7 @@ mod tests {
             let channels = edges
                 .clone()
                 .into_iter()
-                .map(SimulatedChannel::from)
+                .map(|c| SimulatedChannel::new(c.capacity_msat, c.scid, c.node_1, c.node_2, false))
                 .collect::<Vec<SimulatedChannel>>();
 
             Arc::new(populate_network_graph(channels, Arc::clone(&clock)).unwrap())


### PR DESCRIPTION
With this version on sim-ln, we'll no longer include the attacker's "excluded" channels in our random activity generation. This prevents the simulation from sending more payments in the attack time graph than it would it the peacetime graph (which would make us over-estimate revenue under attack).