### PR TITLE
Add ability to run with/without reputation in forward-builder

### DIFF
--- a/ln-simln-jamming/src/bin/forward_builder.rs
+++ b/ln-simln-jamming/src/bin/forward_builder.rs
@@ -123,6 +123,12 @@ async fn main() -> Result<(), BoxError> {
 
     simulation.run(&validated_activities).await?;
 
+    log::info!(
+        "Simulation sent: {} payment with success rate: {}",
+        simulation.get_total_payments().await,
+        simulation.get_success_rate().await
+    );
+
     Ok(())
 }
 

--- a/ln-simln-jamming/src/main.rs
+++ b/ln-simln-jamming/src/main.rs
@@ -294,6 +294,11 @@ async fn main() -> Result<(), BoxError> {
 
     // Run simulation until it shuts down, then wait for the graph to exit.
     simulation.run(&validated_activities).await?;
+    log::info!(
+        "Simulation sent: {} payment with success rate: {}",
+        simulation.get_total_payments().await,
+        simulation.get_success_rate().await
+    );
 
     // Write start and end state to a summary file.
     let end_reputation = get_network_reputation(

--- a/ln-simln-jamming/src/main.rs
+++ b/ln-simln-jamming/src/main.rs
@@ -241,7 +241,7 @@ async fn main() -> Result<(), BoxError> {
         exclude,
     };
 
-    let sim_cfg = SimulationCfg::new(None, 3_800_000, 2.0, None, Some(13995354354227336701));
+    let sim_cfg = SimulationCfg::from(cli.sim_ln);
     let (simulation, validated_activities, sim_nodes) = create_simulation_with_network(
         sim_cfg,
         &sim_params,


### PR DESCRIPTION
It's interesting to be able to run the network with reputation enabled/disabled to get an idea of the impact of the reputation system on the network in times of peace. 

Rather than add this to our main simulation (which has an attack), this PR adds an option to the forward-builder tool to just be able to run the simulation.

Right now, we just run the simulation with no additional analysis, which provides us with payment count / success rates. If we're interested in more information we can possibly expand the interceptors that we use to track more information.