### PR TITLE
gitattributes: use lfs to track traffic files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+peacetime_traffic.csv filter=lfs diff=lfs merge=lfs -text
+attacktime_traffic.csv filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
Trying to set up git LFS to track large files in the repo, some stackoverflow answers note that GH might want this file checked into main before you can push large files. 

Currently failing with:
```
batch response: Git LFS is disabled for this repository.
Uploading LFS objects:   0% (0/1), 0 B | 0 B/s, done.
error: failed to push some refs to 'https://github.com/carlaKC/jam-ln.git'
```

Have not hit my free LFS limit on github and it _seems_ like this should just be enabled by default.