### PR TITLE
Pluggable reputation algorithms + experiment labels

### DIFF
--- a/ln-resource-mgr/src/forward_manager.rs
+++ b/ln-resource-mgr/src/forward_manager.rs
@@ -3,7 +3,7 @@ use crate::incoming_channel::{BucketParameters, IncomingChannel};
 use crate::outgoing_channel::OutgoingChannel;
 use crate::{
     AllocationCheck, BucketResources, ChannelSnapshot, ForwardResolution, ForwardingOutcome,
-    HtlcRef, ProposedForward, ReputationCheck, ReputationError, ReputationManager,
+    HtlcRef, ProposedForward, ReputationAlgo, ReputationCheck, ReputationError, ReputationManager,
     ReputationParams, ResourceBucketType, ResourceCheck,
 };
 use std::collections::hash_map::Entry;
@@ -36,6 +36,7 @@ impl Default for ForwardManagerParams {
                 reputation_multiplier: 12,
                 resolution_period: Duration::from_secs(90),
                 expected_block_speed: Some(Duration::from_secs(10 * 60)),
+                algo: ReputationAlgo::default(),
             },
             general_slot_portion: 40,
             general_liquidity_portion: 40,
@@ -489,7 +490,7 @@ mod tests {
     use crate::{
         forward_manager::{ForwardManager, SimulationDebugManager},
         AccountableSignal, ChannelSnapshot, FailureReason, ForwardingOutcome, HtlcRef,
-        ProposedForward, ReputationError, ReputationManager, ReputationParams,
+        ProposedForward, ReputationAlgo, ReputationError, ReputationManager, ReputationParams,
     };
 
     #[test]
@@ -534,6 +535,7 @@ mod tests {
                 reputation_multiplier: 10,
                 resolution_period: Duration::from_secs(90),
                 expected_block_speed: None,
+                algo: ReputationAlgo::Original,
             },
             general_slot_portion: 30,
             general_liquidity_portion: 30,

--- a/ln-resource-mgr/src/htlc_manager.rs
+++ b/ln-resource-mgr/src/htlc_manager.rs
@@ -15,6 +15,16 @@ pub(super) struct InFlightHtlc {
     pub(super) bucket: ResourceBucketType,
 }
 
+/// Selects the reputation scoring algorithm. New algorithms can be added as a variant here plus a
+/// match arm in [`ReputationParams::opportunity_cost`].
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum ReputationAlgo {
+    /// Pre-existing behaviour: stepwise opportunity cost `floor(hold/period) × fee` — zero below one
+    /// resolution period, then one fee per full period. This is the default.
+    #[default]
+    Original,
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct ReputationParams {
     /// The period of time that revenue should be tracked to determine the threshold for reputation decisions.
@@ -26,13 +36,20 @@ pub struct ReputationParams {
     /// Expected block speed, surfaced to allow test networks to set different durations, defaults to 10 minutes
     /// otherwise.
     pub expected_block_speed: Option<Duration>,
+    /// The opportunity-cost algorithm in use.
+    pub algo: ReputationAlgo,
 }
 
 impl ReputationParams {
-    /// Calculates the opportunity_cost of a htlc being held on our channel - allowing one [`reputation_period`]'s
-    /// grace period, then charging for every subsequent period.
+    /// Calculates the opportunity_cost of a htlc being held on our channel, per the selected
+    /// [`ReputationAlgo`]:
+    /// - `Original`: stepwise `floor(hold/period) × fee` — zero below one period, one fee per period.
     pub(super) fn opportunity_cost(&self, fee_msat: u64, hold_time: Duration) -> u64 {
-        (hold_time.as_secs() / self.resolution_period.as_secs()).saturating_mul(fee_msat)
+        match self.algo {
+            ReputationAlgo::Original => {
+                (hold_time.as_secs() / self.resolution_period.as_secs()).saturating_mul(fee_msat)
+            }
+        }
     }
 
     /// Calculates the worst case reputation damage of a htlc, assuming it'll be held for its full expiry_delta.
@@ -197,7 +214,8 @@ mod tests {
 
     use crate::htlc_manager::{ChannelFilter, InFlightManager};
     use crate::{
-        AccountableSignal, HtlcRef, ReputationError, ReputationParams, ResourceBucketType,
+        AccountableSignal, HtlcRef, ReputationAlgo, ReputationError, ReputationParams,
+        ResourceBucketType,
     };
 
     use super::InFlightHtlc;
@@ -208,6 +226,7 @@ mod tests {
             reputation_multiplier: 10,
             resolution_period: Duration::from_secs(60),
             expected_block_speed: Some(Duration::from_secs(60 * 10)),
+            algo: ReputationAlgo::Original,
         })
     }
 

--- a/ln-resource-mgr/src/htlc_manager.rs
+++ b/ln-resource-mgr/src/htlc_manager.rs
@@ -23,6 +23,10 @@ pub enum ReputationAlgo {
     /// resolution period, then one fee per full period. This is the default.
     #[default]
     Original,
+    /// Gradual opportunity cost (lightning/bolts#1280 / jam-ln#119): `max(0, (hold − period) /
+    /// period) × fee` — linear above the resolution period (no stair-steps / discontinuity), still
+    /// zero below it.
+    Gradual,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -44,10 +48,16 @@ impl ReputationParams {
     /// Calculates the opportunity_cost of a htlc being held on our channel, per the selected
     /// [`ReputationAlgo`]:
     /// - `Original`: stepwise `floor(hold/period) × fee` — zero below one period, one fee per period.
+    /// - `Gradual`:  `max(0, (hold − period)/period) × fee` — linear above the period, zero below.
     pub(super) fn opportunity_cost(&self, fee_msat: u64, hold_time: Duration) -> u64 {
         match self.algo {
             ReputationAlgo::Original => {
                 (hold_time.as_secs() / self.resolution_period.as_secs()).saturating_mul(fee_msat)
+            }
+            ReputationAlgo::Gradual => {
+                let period = self.resolution_period.as_secs_f64();
+                let periods_over = ((hold_time.as_secs_f64() - period) / period).max(0.0);
+                (periods_over * fee_msat as f64).round() as u64
             }
         }
     }

--- a/ln-resource-mgr/src/incoming_channel.rs
+++ b/ln-resource-mgr/src/incoming_channel.rs
@@ -448,6 +448,7 @@ impl GeneralBucket {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ReputationAlgo;
     use std::collections::HashSet;
 
     const TEST_BUCKET_PARAMS: BucketParameters = BucketParameters {
@@ -623,6 +624,7 @@ mod tests {
             reputation_multiplier: 10,
             resolution_period: Duration::from_secs(90),
             expected_block_speed: None,
+            algo: ReputationAlgo::Original,
         };
 
         let now = Instant::now();

--- a/ln-resource-mgr/src/lib.rs
+++ b/ln-resource-mgr/src/lib.rs
@@ -1,6 +1,6 @@
 mod decaying_average;
 pub mod forward_manager;
-pub use htlc_manager::ReputationParams;
+pub use htlc_manager::{ReputationAlgo, ReputationParams};
 mod htlc_manager;
 mod incoming_channel;
 mod outgoing_channel;

--- a/ln-resource-mgr/src/outgoing_channel.rs
+++ b/ln-resource-mgr/src/outgoing_channel.rs
@@ -101,7 +101,7 @@ impl OutgoingChannel {
 mod tests {
     use std::time::{Duration, Instant};
 
-    use crate::htlc_manager::ReputationParams;
+    use crate::htlc_manager::{ReputationAlgo, ReputationParams};
     use crate::{AccountableSignal, ForwardResolution, ResourceBucketType};
 
     use super::{InFlightHtlc, OutgoingChannel};
@@ -112,6 +112,7 @@ mod tests {
             reputation_multiplier: 10,
             resolution_period: Duration::from_secs(60),
             expected_block_speed: Some(Duration::from_secs(60 * 10)),
+            algo: ReputationAlgo::Original,
         }
     }
 

--- a/ln-resource-mgr/src/outgoing_channel.rs
+++ b/ln-resource-mgr/src/outgoing_channel.rs
@@ -147,6 +147,20 @@ mod tests {
     }
 
     #[test]
+    fn test_gradual_opportunity_cost() {
+        // Gradual (#119): max(0, (hold − period)/period) × fee — linear above the period, 0 below.
+        let params = ReputationParams {
+            algo: ReputationAlgo::Gradual,
+            ..get_test_params() // resolution_period = 60s
+        };
+        assert_eq!(params.opportunity_cost(100, Duration::from_secs(30)), 0); // below period
+        assert_eq!(params.opportunity_cost(100, Duration::from_secs(60)), 0); // at the boundary
+        assert_eq!(params.opportunity_cost(100, Duration::from_secs(90)), 50); // (90-60)/60 = 0.5
+        assert_eq!(params.opportunity_cost(100, Duration::from_secs(120)), 100); // 1 period over
+        assert_eq!(params.opportunity_cost(100, Duration::from_secs(600)), 900);
+    }
+
+    #[test]
     fn test_effective_fees() {
         let params = get_test_params();
         let fast_resolve = params.resolution_period / 2;

--- a/ln-simln-jamming/src/main.rs
+++ b/ln-simln-jamming/src/main.rs
@@ -92,8 +92,13 @@ async fn main() -> Result<(), BoxError> {
     let now = InstantClock::now(&*clock);
 
     // Create a writer to store results for nodes that we care about.
+    // Label groups this experiment's results; defaults to the reputation algorithm name.
+    let label = cli
+        .label
+        .clone()
+        .unwrap_or_else(|| cli.reputation_params.reputation_algo.name().to_string());
     let results_dir = network
-        .results_dir(Clock::now(&*clock))
+        .results_dir(Clock::now(&*clock), &label)
         .ok_or("results dir none for attack")?;
     if !results_dir.exists() {
         fs::create_dir_all(&results_dir)?;

--- a/ln-simln-jamming/src/parsing.rs
+++ b/ln-simln-jamming/src/parsing.rs
@@ -12,7 +12,7 @@ use csv::{ReaderBuilder, StringRecord};
 use humantime::Duration as HumanDuration;
 use lightning::routing::gossip::NetworkGraph;
 use ln_resource_mgr::forward_manager::ForwardManagerParams;
-use ln_resource_mgr::ChannelSnapshot;
+use ln_resource_mgr::{ChannelSnapshot, ReputationAlgo};
 use log::LevelFilter;
 use serde::{Deserialize, Serialize};
 use sim_cli::parsing::NetworkParser;
@@ -49,6 +49,31 @@ pub const DEFAULT_REPUTATION_MARGIN_EXIPRY: &str = "200";
 /// The default batch size for writing results to disk.
 pub const DEFAULT_RESULT_BATCH_SIZE: &str = "500";
 
+/// CLI selector for the reputation scoring algorithm. Maps to [`ReputationAlgo`]; add a variant here
+/// (and the match arm) when a new named algorithm is added in ln-resource-mgr.
+#[derive(Clone, Copy, Debug, ValueEnum)]
+pub enum ReputationAlgoArg {
+    /// Pre-existing stepwise opportunity cost.
+    Original,
+}
+
+impl ReputationAlgoArg {
+    /// Canonical name (used as the default experiment label).
+    pub fn name(&self) -> &'static str {
+        match self {
+            ReputationAlgoArg::Original => "original",
+        }
+    }
+}
+
+impl From<ReputationAlgoArg> for ReputationAlgo {
+    fn from(arg: ReputationAlgoArg) -> Self {
+        match arg {
+            ReputationAlgoArg::Original => ReputationAlgo::Original,
+        }
+    }
+}
+
 #[derive(Clone, Parser)]
 pub struct ReputationParams {
     /// The window over which the value of a link's revenue to our node is calculated.
@@ -58,6 +83,10 @@ pub struct ReputationParams {
     /// The multiplier applied to revenue_window_seconds to get the duration over which reputation is bootstrapped.
     #[arg(long)]
     pub reputation_multiplier: Option<u8>,
+
+    /// The reputation scoring algorithm to use. Defaults to the pre-existing `original`.
+    #[arg(long, value_enum, default_value_t = ReputationAlgoArg::Original)]
+    pub reputation_algo: ReputationAlgoArg,
 }
 
 impl From<ReputationParams> for ForwardManagerParams {
@@ -69,6 +98,7 @@ impl From<ReputationParams> for ForwardManagerParams {
         if let Some(multiplier) = cli.reputation_multiplier {
             forward_params.reputation_params.reputation_multiplier = multiplier;
         }
+        forward_params.reputation_params.algo = cli.reputation_algo.into();
         forward_params
     }
 }
@@ -177,9 +207,10 @@ impl NetworkType {
         }
     }
 
-    /// Returns a directory to write simulation results to, if appropriate for network type,
-    /// namespacing by the runtime provided.
-    pub fn results_dir(&self, now: SystemTime) -> Option<PathBuf> {
+    /// Returns a directory to write simulation results to, if appropriate for network type:
+    /// `results/{Attack}/{label}/{seconds_since_epoch}`. The label groups runs of the same
+    /// experiment (e.g. by reputation algorithm) for easier comparison.
+    pub fn results_dir(&self, now: SystemTime, label: &str) -> Option<PathBuf> {
         match self {
             NetworkType::Peacetime(_) => None,
             NetworkType::AttackTime(_, a) | NetworkType::BootstrapAttackTime(_, a, _) => {
@@ -188,6 +219,7 @@ impl NetworkType {
                 Some(
                     PathBuf::from("results")
                         .join(format!("{:?}", a.attack))
+                        .join(label)
                         .join(sec_since_epoch.to_string()),
                 )
             }
@@ -432,6 +464,11 @@ pub struct Cli {
 
     #[command(flatten)]
     pub reputation_params: ReputationParams,
+
+    /// Optional label for this experiment. Results are written to
+    /// `results/{Attack}/{label}/{timestamp}`. Defaults to the reputation algorithm name.
+    #[arg(long)]
+    pub label: Option<String>,
 
     #[clap(long, default_value = "debug")]
     pub log_level: LevelFilter,

--- a/ln-simln-jamming/src/parsing.rs
+++ b/ln-simln-jamming/src/parsing.rs
@@ -55,6 +55,9 @@ pub const DEFAULT_RESULT_BATCH_SIZE: &str = "500";
 pub enum ReputationAlgoArg {
     /// Pre-existing stepwise opportunity cost.
     Original,
+    /// Gradual opportunity cost (bolts#1280 / jam-ln#119): linear above the resolution period, zero
+    /// below, no stair-steps.
+    Gradual,
 }
 
 impl ReputationAlgoArg {
@@ -62,6 +65,7 @@ impl ReputationAlgoArg {
     pub fn name(&self) -> &'static str {
         match self {
             ReputationAlgoArg::Original => "original",
+            ReputationAlgoArg::Gradual => "gradual",
         }
     }
 }
@@ -70,6 +74,7 @@ impl From<ReputationAlgoArg> for ReputationAlgo {
     fn from(arg: ReputationAlgoArg) -> Self {
         match arg {
             ReputationAlgoArg::Original => ReputationAlgo::Original,
+            ReputationAlgoArg::Gradual => ReputationAlgo::Gradual,
         }
     }
 }

--- a/ln-simln-jamming/src/reputation_interceptor.rs
+++ b/ln-simln-jamming/src/reputation_interceptor.rs
@@ -621,7 +621,8 @@ mod tests {
     };
     use ln_resource_mgr::{
         AccountableSignal, AllocationCheck, ChannelSnapshot, ForwardResolution, ForwardingOutcome,
-        HtlcRef, ProposedForward, ReputationError, ReputationManager, ReputationParams,
+        HtlcRef, ProposedForward, ReputationAlgo, ReputationError, ReputationManager,
+        ReputationParams,
     };
     use mockall::mock;
     use sim_cli::parsing::NetworkParser;
@@ -928,6 +929,7 @@ mod tests {
                 reputation_multiplier: 60,
                 resolution_period: Duration::from_secs(90),
                 expected_block_speed: None,
+                algo: ReputationAlgo::Original,
             },
             general_slot_portion: 30,
             general_liquidity_portion: 30,


### PR DESCRIPTION
## Description

Makes it cheap to add and compare reputation scoring algorithms in the simulator.

  A `ReputationAlgo` enum on `ReputationParams` selects the opportunity-cost scoring rule, dispatched in `opportunity_cost`. Adding an algorithm is now a localised change: one enum variant, one match arm, one CLI value. Two are provided:

  - **`original`** (default) — the pre-existing stepwise cost `floor(hold/period) × fee`.
  - **`gradual`** — a continuous cost `max(0, (hold − period)/period) × fee`: linear above the resolution period, zero below, no stair-step at each boundary (same formula as #120, absorbed that commit on this PR to demonstrate the addition).

Select via `--reputation-algo` (default `original`). A new `--label` flag namespaces output to `results/{Attack}/{label}/{timestamp}` (label defaults to the algo name), so runs of the same experiment group together. The only change to existing runs is the results path layout — scoring is untouched at the default.

### Rationale

Want to experiment with a few adjustments to the HTLC opportunity cost formula, which could (possibly) help us mitigate fast jamming too. This PR was created in order to make comparison of different algos a more easy and straight forward process.