### PR TITLE
Add new attack types (`slow-slot`, `fast-slot`, `fast-liq`)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,11 @@ data
 results/*
 reputation_*
 revenue_*
+
+# Generated simulation data (rebuilt on demand by the Makefile / setup script).
+networks/*/peacetime_traffic.csv
+networks/*/reputation.csv
+# Attack-time networks the setup script derives from the tracked SlowJam template.
+networks/*/attacks/SlowSlotJam/
+networks/*/attacks/FastSlotJam/
+networks/*/attacks/FastLiqJam/

--- a/Makefile
+++ b/Makefile
@@ -18,3 +18,101 @@ install-tools:
 
 install:
 	cargo install --locked --path ln-simln-jamming
+
+# ============================================================================
+# Slot / liquidity jamming experiments — one command, data grabbed automatically
+# ============================================================================
+# `make <attack>` builds the binaries, generates the peacetime traffic + reputation
+# snapshot if they're missing (cached afterwards), positions the attacker, runs the
+# attack, and prints the summary. Override any VAR=value:
+#
+#   make slow-slot-jam                                   # quick demo (~20 min first run)
+#   make slow-slot-jam JAM_DURATION=8w TRAFFIC_DURATION=10w   # the headline economics
+#   make fast-slot-jam REPUTATION_ALGO=gradual           # compare an algorithm
+#   make sim-clean-data                                  # drop generated data to regenerate
+#   make sim-help                                        # list the knobs
+
+NET               ?= networks/ln_slow_jam
+SPEEDUP           ?= 200
+# How long to sustain the jam. TRAFFIC_DURATION must be >= JAM_DURATION (the live revenue
+# counterfactual replays the raw traffic file over the jam).
+JAM_DURATION      ?= 1d
+# Peacetime traffic to generate. Kept short: reputation-builder --allow-boost tiles it to fill the
+# (unchanged, protocol-default) 6-month reputation window, so a week of traffic bootstraps full
+# reputation without generating months of data. Grow it for longer jams.
+TRAFFIC_DURATION  ?= 1w
+REPUTATION_ALGO   ?= original
+# Experiment placement (defaults reproduce the busy, low-base-fee target in ln_slow_jam):
+TARGET_ALIAS      ?= 2
+CHANNEL_TO_JAM    ?= 570646534881280
+SENDER_ALIAS      ?= 25
+RECEIVER_ALIAS    ?= 70
+# Fee on the target->receiver channel (the hop the held HTLCs exit through) — drives the attacker's
+# one-time entry cost via htlc_risk, not the denied revenue. We model 0-base-fee target channels (a
+# common LN policy): with 0 base, dust slot-jam HTLCs carry ~no fee so their htlc_risk ~ 0 and entry
+# collapses to the revenue threshold. The proportional fee still gates large liquidity-jam HTLCs.
+RECEIVER_BASE_FEE ?= 0
+RECEIVER_PROP_FEE ?= 100
+LABEL             ?= $(ATTACK)
+
+SIM   := ./target/release/ln-simln-jamming
+FWD   := ./target/release/forward-builder
+REP   := ./target/release/reputation-builder
+SETUP := python3 ln-simln-jamming/scripts/setup_attack_network.py
+
+.PHONY: bins
+bins:
+	cargo build --release --bins
+
+# Prerequisites generated on demand and cached. Order-only dep on `bins` so an updated
+# binary doesn't force traffic/reputation to regenerate.
+$(NET)/peacetime_traffic.csv: | bins
+	@echo ">> generating $(TRAFFIC_DURATION) of peacetime traffic (one-time, cached)..."
+	$(FWD) --network-dir $(NET) --duration $(TRAFFIC_DURATION)
+
+$(NET)/reputation.csv: $(NET)/peacetime_traffic.csv | bins
+	@echo ">> bootstrapping reputation snapshot from $(TRAFFIC_DURATION) of traffic (boosted to fill the full window)..."
+	$(REP) --network-dir $(NET) --allow-boost
+
+# The three slot/liquidity attacks. ATTACK = CLI name, DIR = results/<DIR> (Debug form).
+.PHONY: slow-slot-jam fast-slot-jam fast-liq-jam
+slow-slot-jam: ; @$(MAKE) --no-print-directory run ATTACK=slow-slot-jam DIR=SlowSlotJam
+fast-slot-jam: ; @$(MAKE) --no-print-directory run ATTACK=fast-slot-jam DIR=FastSlotJam
+fast-liq-jam:  ; @$(MAKE) --no-print-directory run ATTACK=fast-liq-jam  DIR=FastLiqJam
+
+.PHONY: run
+run: bins $(NET)/reputation.csv
+	@echo ">> positioning attacker for $(DIR)..."
+	$(SETUP) --network-dir $(NET) --attack $(DIR) --target-alias $(TARGET_ALIAS) \
+		--channel-to-jam-scid $(CHANNEL_TO_JAM) --sender-alias $(SENDER_ALIAS) \
+		--receiver-alias $(RECEIVER_ALIAS) --receiver-base-fee $(RECEIVER_BASE_FEE) \
+		--receiver-prop-fee $(RECEIVER_PROP_FEE)
+	@echo ">> running $(ATTACK) (jam $(JAM_DURATION), speedup $(SPEEDUP), algo $(REPUTATION_ALGO))..."
+	$(SIM) --network-dir $(NET) --attack-type $(ATTACK) --target-alias $(TARGET_ALIAS) \
+		--channel-to-jam-scid $(CHANNEL_TO_JAM) --jam-duration $(JAM_DURATION) \
+		--clock-speedup $(SPEEDUP) --reputation-algo $(REPUTATION_ALGO) \
+		--target-reputation-percent 1 --label $(LABEL)
+	@$(MAKE) --no-print-directory sim-results DIR=$(DIR) LABEL=$(LABEL)
+
+.PHONY: sim-results
+sim-results:
+	@echo ""; echo "===== $(DIR) / $(LABEL) summary ====="
+	@cat "$$(ls -dt results/$(DIR)/$(LABEL)/*/summary.txt 2>/dev/null | head -1)" 2>/dev/null \
+		|| echo "(no summary found for results/$(DIR)/$(LABEL))"
+
+.PHONY: sim-clean-data
+sim-clean-data:
+	rm -f $(NET)/peacetime_traffic.csv $(NET)/reputation.csv
+	@echo "removed generated traffic + reputation for $(NET); next run regenerates them"
+
+.PHONY: sim-help
+sim-help:
+	@echo "Attacks:   make {slow-slot-jam | fast-slot-jam | fast-liq-jam}"
+	@echo "Knobs (VAR=value):"
+	@echo "  NET=$(NET)                  network directory"
+	@echo "  JAM_DURATION=$(JAM_DURATION)             how long to sustain the jam"
+	@echo "  TRAFFIC_DURATION=$(TRAFFIC_DURATION)     peacetime traffic to generate (>= JAM_DURATION)"
+	@echo "  SPEEDUP=$(SPEEDUP)                 clock speedup (keep <= 200)"
+	@echo "  REPUTATION_ALGO=$(REPUTATION_ALGO)     original | gradual"
+	@echo "  TARGET_ALIAS / CHANNEL_TO_JAM / SENDER_ALIAS / RECEIVER_ALIAS / RECEIVER_BASE_FEE"
+	@echo "Other:     make sim-clean-data   (regenerate traffic/reputation)"

--- a/ln-resource-mgr/src/forward_manager.rs
+++ b/ln-resource-mgr/src/forward_manager.rs
@@ -11,6 +11,10 @@ use std::collections::HashMap;
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
+/// The maximum number of in-flight HTLC slots a channel exposes (BOLT `max_accepted_htlcs`), split
+/// across the general/congestion/protected buckets by the configured portions.
+pub const MAX_HTLC_SLOTS: u16 = 483;
+
 /// Tracks reputation and revenue for a channel.
 #[derive(Debug)]
 struct TrackedChannel {
@@ -241,11 +245,13 @@ impl ReputationManager for ForwardManager {
         {
             Entry::Occupied(_) => Err(ReputationError::ErrChannelExists(channel_id)),
             Entry::Vacant(v) => {
-                let general_slot_count = 483 * self.params.general_slot_portion as u16 / 100;
+                let general_slot_count =
+                    MAX_HTLC_SLOTS * self.params.general_slot_portion as u16 / 100;
                 let general_liquidity_amount =
                     capacity_msat * self.params.general_liquidity_portion as u64 / 100;
 
-                let congestion_slot_count = 483 * self.params.congestion_slot_portion as u16 / 100;
+                let congestion_slot_count =
+                    MAX_HTLC_SLOTS * self.params.congestion_slot_portion as u16 / 100;
                 let congestion_liquidity_amount =
                     capacity_msat * self.params.congestion_liquidity_portion as u64 / 100;
 
@@ -256,7 +262,7 @@ impl ReputationManager for ForwardManager {
                     - self.params.general_liquidity_portion
                     - self.params.congestion_liquidity_portion;
 
-                let protected_slot_count = 483 * protected_slot_portion as u16 / 100;
+                let protected_slot_count = MAX_HTLC_SLOTS * protected_slot_portion as u16 / 100;
                 let protected_liquidity_amount =
                     capacity_msat * protected_liquidity_portion as u64 / 100;
 

--- a/ln-resource-mgr/src/forward_manager.rs
+++ b/ln-resource-mgr/src/forward_manager.rs
@@ -3,7 +3,7 @@ use crate::incoming_channel::{BucketParameters, IncomingChannel};
 use crate::outgoing_channel::OutgoingChannel;
 use crate::{
     AllocationCheck, BucketResources, ChannelSnapshot, ForwardResolution, ForwardingOutcome,
-    HtlcRef, ProposedForward, ReputationCheck, ReputationError, ReputationManager,
+    HtlcRef, ProposedForward, ReputationAlgo, ReputationCheck, ReputationError, ReputationManager,
     ReputationParams, ResourceBucketType, ResourceCheck,
 };
 use std::collections::hash_map::Entry;
@@ -40,6 +40,7 @@ impl Default for ForwardManagerParams {
                 reputation_multiplier: 12,
                 resolution_period: Duration::from_secs(90),
                 expected_block_speed: Some(Duration::from_secs(10 * 60)),
+                algo: ReputationAlgo::default(),
             },
             general_slot_portion: 40,
             general_liquidity_portion: 40,
@@ -495,7 +496,7 @@ mod tests {
     use crate::{
         forward_manager::{ForwardManager, SimulationDebugManager},
         AccountableSignal, ChannelSnapshot, FailureReason, ForwardingOutcome, HtlcRef,
-        ProposedForward, ReputationError, ReputationManager, ReputationParams,
+        ProposedForward, ReputationAlgo, ReputationError, ReputationManager, ReputationParams,
     };
 
     #[test]
@@ -540,6 +541,7 @@ mod tests {
                 reputation_multiplier: 10,
                 resolution_period: Duration::from_secs(90),
                 expected_block_speed: None,
+                algo: ReputationAlgo::Gradual,
             },
             general_slot_portion: 30,
             general_liquidity_portion: 30,

--- a/ln-resource-mgr/src/htlc_manager.rs
+++ b/ln-resource-mgr/src/htlc_manager.rs
@@ -15,6 +15,30 @@ pub(super) struct InFlightHtlc {
     pub(super) bucket: ResourceBucketType,
 }
 
+/// Selects the reputation scoring algorithm. New algorithms can be added as a variant here plus a
+/// match arm in [`ReputationParams::opportunity_cost`].
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum ReputationAlgo {
+    /// Pre-existing behaviour: stepwise opportunity cost `floor(hold/period) × fee` — zero below one
+    /// resolution period, then one fee per full period. Selectable for comparison against `Gradual`.
+    Original,
+    /// Gradual opportunity cost (lightning/bolts#1280 / jam-ln#119): `max(0, (hold − period) /
+    /// period) × fee` — linear above the resolution period (no stair-steps / discontinuity), still
+    /// zero below it. This is the default (matches the behaviour on `master`).
+    #[default]
+    Gradual,
+    /// Ramp opportunity cost: free below a short [`RAMP_FREE_GRACE`] grace, then linear up to one
+    /// fee at the resolution period (`fee × (hold − grace) / (period − grace)`), then continuing at
+    /// the gradual rate above the period (`fee × hold / period` — one fee at the period, one extra
+    /// fee per period thereafter). Unlike `Original`/`Gradual` it charges for sub-period holds,
+    /// closing the "free" window that fast jams exploit. Continuous and strictly increasing.
+    Ramp,
+}
+
+/// Holds shorter than this accrue no opportunity cost under [`ReputationAlgo::Ramp`] — a small grace
+/// period before the linear ramp begins.
+const RAMP_FREE_GRACE: Duration = Duration::from_secs(5);
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct ReputationParams {
     /// The period of time that revenue should be tracked to determine the threshold for reputation decisions.
@@ -26,17 +50,42 @@ pub struct ReputationParams {
     /// Expected block speed, surfaced to allow test networks to set different durations, defaults to 10 minutes
     /// otherwise.
     pub expected_block_speed: Option<Duration>,
+    /// The opportunity-cost algorithm in use.
+    pub algo: ReputationAlgo,
 }
 
 impl ReputationParams {
-    /// Calculates the opportunity_cost of a htlc being held on our channel - allowing one [`reputation_period`]'s
-    /// grace period, then charging for every subsequent period.
+    /// Calculates the opportunity_cost of a htlc being held on our channel, per the selected
+    /// [`ReputationAlgo`]:
+    /// - `Original`: stepwise `floor(hold/period) × fee` — zero below one period, one fee per period.
+    /// - `Gradual`:  `max(0, (hold − period)/period) × fee` — linear above the period, zero below.
+    /// - `Ramp`:     free below the grace, linear to one fee at the period, then `fee × hold/period`.
     pub(super) fn opportunity_cost(&self, fee_msat: u64, hold_time: Duration) -> u64 {
-        (0_f64.max(
-            (hold_time.as_secs_f64() - self.resolution_period.as_secs_f64())
-                / self.resolution_period.as_secs_f64(),
-        ) * (fee_msat as f64))
-            .round() as u64
+        match self.algo {
+            ReputationAlgo::Original => {
+                (hold_time.as_secs() / self.resolution_period.as_secs()).saturating_mul(fee_msat)
+            }
+            ReputationAlgo::Gradual => {
+                let period = self.resolution_period.as_secs_f64();
+                let periods_over = ((hold_time.as_secs_f64() - period) / period).max(0.0);
+                (periods_over * fee_msat as f64).round() as u64
+            }
+            ReputationAlgo::Ramp => {
+                let period = self.resolution_period.as_secs_f64();
+                let hold = hold_time.as_secs_f64();
+                let grace = RAMP_FREE_GRACE.as_secs_f64();
+                let fee = fee_msat as f64;
+                if hold < grace {
+                    0
+                } else if hold < period {
+                    // Linear ramp from 0 at the grace to one fee at the resolution period.
+                    (fee * (hold - grace) / (period - grace)).round() as u64
+                } else {
+                    // One fee at the period, then the gradual per-period rate above it.
+                    (fee * hold / period).round() as u64
+                }
+            }
+        }
     }
 
     /// Calculates the worst case reputation damage of a htlc, assuming it'll be held for its full expiry_delta.
@@ -201,7 +250,8 @@ mod tests {
 
     use crate::htlc_manager::{ChannelFilter, InFlightManager};
     use crate::{
-        AccountableSignal, HtlcRef, ReputationError, ReputationParams, ResourceBucketType,
+        AccountableSignal, HtlcRef, ReputationAlgo, ReputationError, ReputationParams,
+        ResourceBucketType,
     };
 
     use super::InFlightHtlc;
@@ -212,6 +262,7 @@ mod tests {
             reputation_multiplier: 10,
             resolution_period: Duration::from_secs(60),
             expected_block_speed: Some(Duration::from_secs(60 * 10)),
+            algo: ReputationAlgo::Gradual,
         })
     }
 

--- a/ln-resource-mgr/src/incoming_channel.rs
+++ b/ln-resource-mgr/src/incoming_channel.rs
@@ -448,6 +448,7 @@ impl GeneralBucket {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ReputationAlgo;
     use std::collections::HashSet;
 
     const TEST_BUCKET_PARAMS: BucketParameters = BucketParameters {
@@ -623,6 +624,7 @@ mod tests {
             reputation_multiplier: 10,
             resolution_period: Duration::from_secs(90),
             expected_block_speed: None,
+            algo: ReputationAlgo::Gradual,
         };
 
         let now = Instant::now();

--- a/ln-resource-mgr/src/lib.rs
+++ b/ln-resource-mgr/src/lib.rs
@@ -1,6 +1,6 @@
 mod decaying_average;
 pub mod forward_manager;
-pub use htlc_manager::ReputationParams;
+pub use htlc_manager::{ReputationAlgo, ReputationParams};
 mod htlc_manager;
 mod incoming_channel;
 mod outgoing_channel;

--- a/ln-resource-mgr/src/outgoing_channel.rs
+++ b/ln-resource-mgr/src/outgoing_channel.rs
@@ -101,7 +101,7 @@ impl OutgoingChannel {
 mod tests {
     use std::time::{Duration, Instant};
 
-    use crate::htlc_manager::ReputationParams;
+    use crate::htlc_manager::{ReputationAlgo, ReputationParams};
     use crate::{AccountableSignal, ForwardResolution, ResourceBucketType};
 
     use super::{InFlightHtlc, OutgoingChannel};
@@ -112,6 +112,7 @@ mod tests {
             reputation_multiplier: 10,
             resolution_period: Duration::from_secs(60),
             expected_block_speed: Some(Duration::from_secs(60 * 10)),
+            algo: ReputationAlgo::Gradual,
         }
     }
 
@@ -144,6 +145,35 @@ mod tests {
 
         // Multiple periods above resolution_period charges multiples of fee.
         assert_eq!(params.opportunity_cost(100, Duration::from_secs(600)), 900);
+    }
+
+    #[test]
+    fn test_original_opportunity_cost() {
+        // Original: stepwise floor(hold/period) × fee — one fee per full period, flat between steps.
+        let params = ReputationParams {
+            algo: ReputationAlgo::Original,
+            ..get_test_params() // resolution_period = 60s
+        };
+        assert_eq!(params.opportunity_cost(100, Duration::from_secs(10)), 0); // below one period
+        assert_eq!(params.opportunity_cost(100, Duration::from_secs(60)), 100); // one full period
+        assert_eq!(params.opportunity_cost(100, Duration::from_secs(65)), 100); // flat within period
+        assert_eq!(params.opportunity_cost(100, Duration::from_secs(600)), 1000);
+    }
+
+    #[test]
+    fn test_ramp_opportunity_cost() {
+        // Ramp: free <5s, linear to 1x fee at the period (60s here), then fee × hold/period above.
+        let params = ReputationParams {
+            algo: ReputationAlgo::Ramp,
+            ..get_test_params() // resolution_period = 60s, grace = 5s
+        };
+        assert_eq!(params.opportunity_cost(100, Duration::from_secs(3)), 0); // below grace
+        assert_eq!(params.opportunity_cost(100, Duration::from_secs(5)), 0); // at grace
+        assert_eq!(params.opportunity_cost(100, Duration::from_secs(16)), 20); // (16-5)/55 = 0.2
+        assert_eq!(params.opportunity_cost(100, Duration::from_secs(38)), 60); // (38-5)/55 = 0.6
+        assert_eq!(params.opportunity_cost(100, Duration::from_secs(60)), 100); // 1x at the period
+        assert_eq!(params.opportunity_cost(100, Duration::from_secs(120)), 200); // +1x per period
+        assert_eq!(params.opportunity_cost(100, Duration::from_secs(600)), 1000);
     }
 
     #[test]

--- a/ln-simln-jamming/docs/slot_liq_jam.md
+++ b/ln-simln-jamming/docs/slot_liq_jam.md
@@ -1,0 +1,186 @@
+# Slot & liquidity jamming experiments
+
+Protected-bucket jamming attacks that hold a target channel's protected resources and refill
+reputation as it decays, so the jam can be sustained. They let you measure **what it costs an
+attacker to keep a channel dark vs. the revenue that channel earns**, against any reputation
+algorithm.
+
+Attacks (all configured by one implementation, `attacks/slot_liq_jam.rs`):
+
+| `--attack-type` | fills protected by | hold | repeats |
+|---|---|---|---|
+| `slow-slot-jam` | one HTLC **per slot** (dust) | full duration | no |
+| `fast-slot-jam` | one HTLC per slot (dust) | ~85s | yes, until `--jam-duration` |
+| `fast-liq-jam` | one **large** HTLC (exhausts liquidity) | ~85s | yes, until `--jam-duration` |
+
+(`slow_jam` already covers slow-liquidity jamming.)
+
+## Quick start (one command)
+
+```sh
+make slow-slot-jam        # or: fast-slot-jam, fast-liq-jam
+```
+
+That single command **grabs everything it needs automatically**: it builds the binaries, generates
+the peacetime traffic and reputation snapshot if they're missing (cached afterwards), positions the
+attacker around the target, runs the attack, and prints the summary. Override any knob inline:
+
+```sh
+make fast-slot-jam REPUTATION_ALGO=gradual               # same attack against another algorithm
+make sim-clean-data                                       # drop generated data to regenerate
+make sim-help                                             # list all knobs
+```
+
+The **defaults run a quick (~20 min first time) demo** with the **protocol-default windows**
+(14-day revenue, 6-month reputation): only a week of traffic is generated, and
+`reputation-builder --allow-boost` tiles it to fill the full reputation window, so reputation is
+bootstrapped over the real window without generating months of data. The demo proves the pipeline
+and the cost/denied relationship; absolute numbers grow with the hold.
+
+To sustain the jam for longer (the headline amortization), grow the hold — and the traffic, since
+the live revenue counterfactual replays the raw traffic over the jam:
+
+```sh
+make slow-slot-jam JAM_DURATION=8w TRAFFIC_DURATION=8w
+```
+
+The rest of this doc explains what these commands do under the hood and how to read the results.
+
+## Prerequisites (the network directory)
+
+`--network-dir <dir>` must contain:
+
+| file | what it is | produced by |
+|---|---|---|
+| `peacetime_network.json` | the honest graph (nodes, channels, fee policies) | provided / your topology |
+| `peacetime_traffic.csv` | forward history used to bootstrap reputation **and** replayed as the live + counterfactual traffic during the attack | `forward-builder` |
+| `reputation.csv` | bootstrapped reputation snapshot the sim seeds from | `reputation-builder` |
+| `target.txt` | alias of the node under attack | you |
+| `attacks/<AttackType>/attacktime_network.json` | graph during the attack = peacetime graph **+ attacker channels** | derived from peacetime |
+| `attacks/<AttackType>/attacker.csv` | attacker aliases (e.g. `70,25`) | you |
+
+Build the traffic + reputation:
+
+```sh
+# 1. generate peacetime traffic (see forward-builder --help; --duration accepts 7d / 6m)
+cargo run --release --bin forward-builder -- --network-dir <dir> --duration 6m
+
+# 2. bootstrap the reputation snapshot from it
+cargo run --release --bin reputation-builder -- --network-dir <dir>
+```
+
+The `attacks/<AttackType>/` directory is named after the `Debug` form of the attack
+(`SlowSlotJam`, `FastSlotJam`, `FastLiqJam`). Reuse one attack's `attacktime_network.json` for
+another by copying the directory.
+
+### Attacker placement (the one non-obvious requirement)
+
+The attacker must be **positioned around the target** for the routes to exist:
+
+- attacker **receiver** ↔ target  (reputation is built/held over this channel)
+- attacker **sender** ↔ target  (build route: `sender → target → receiver`)
+- attacker **sender** ↔ peer  (jam route: `sender → peer → target → receiver`, where the
+  `peer ↔ target` channel is the one being jammed)
+
+Add these as attacker channels in `attacktime_network.json` only (they're allowed to differ from
+the peacetime graph because the endpoints are listed in `attacker.csv`). Adding connectivity for
+the attacker is realistic — anyone can open channels.
+
+## Running an experiment
+
+```sh
+cargo run --release --bin ln-simln-jamming -- \
+  --network-dir <dir> \
+  --attack-type slow-slot-jam \
+  --channel-to-jam-scid <scid> \   # which target channel to jam; peer derived from the graph
+  --jam-duration 8w \              # how long to sustain (slow: hold; fast: repeat window)
+  --clock-speedup 200 \            # KEEP <= ~200: latency*speedup must stay < 90s resolution period
+  --target-reputation-percent 1 \  # relax the pre-flight gate (target need not be highly reputable)
+  --reputation-algo original \     # algorithm under test: original | gradual
+  --label my-run                   # results/<Attack>/<label>/<timestamp>/
+```
+
+Key parameters:
+
+- **`--clock-speedup`** — wall-time accelerator. Must stay `<= ~200`: the latency interceptor's
+  sleep is multiplied by the speedup in sim-time, and if it exceeds the 90s resolution period every
+  forward's effective fee zeroes out and reputation can't be built (upstream issue #127).
+- **`--jam-duration`** — holding for several revenue windows is what makes the one-time entry cost
+  amortize below the (accumulating) revenue denied.
+- **`--channel-to-jam-scid`** — re-point the attack at any target channel without recompiling.
+- **`--reputation-algo`** — run the same attack against each algorithm to compare economics.
+
+## Reading the output (`results/<Attack>/<label>/<ts>/summary.txt`)
+
+```
+SlowSlotJam ran for (seconds): 4838587
+Peacetime revenue (msat): 51869334          # target's total fees with no attacker
+Simulation revenue (msat): 30738607         # target's fees during attack (incl. attacker fees!)
+Revenue loss in simulation: 21130727        # net loss = peacetime - simulation
+...
+Target start reputation (pairs): 12/105     # good-reputation channel pairs before
+Target end reputation (pairs): 0/105        # ... and after (collateral: reputation destroyed)
+Attacker cost (msat): 29890461 total = 29369000 entry + 521461 sustaining across 17 cycle(s)
+Honest revenue denied (msat): 51021188      # peacetime - simulation + attacker fees (see below)
+Attacker cost / honest revenue denied: 0.586
+```
+
+How to read it:
+
+- **Attacker cost** splits into a one-time **entry** (build reputation to clear the channel's
+  revenue threshold) and a recurring **sustaining** cost (decay-driven refills over the hold). The
+  sustaining figure is typically scraps — that's the "pay once, hold cheaply" result.
+- **Honest revenue denied** corrects a confound: the attacker builds reputation by routing *through
+  the target*, so its fees are paid *to* the target and inflate `Simulation revenue`. Adding them
+  back (`peacetime − simulation + attacker fees`) recovers the honest revenue actually blocked.
+- **Cost / honest revenue denied** is the headline. `< 1` means jamming is cheaper than the revenue
+  it denies; because the cost is dominated by the one-time entry, the ratio falls as
+  `--jam-duration` grows (≈ `revenue_window / jam_duration`).
+- Note the attacker's fees flow to the victim, so this is a **denial-of-service / griefing** result
+  (service blocked + reputation destroyed), not net revenue extraction.
+
+## Asserting the thesis
+
+The cost is driven by `entry ≈ channel revenue threshold` + `sustaining ≈ slots × per-HTLC fee ×
+hold` — both depend on the **fee policy**, not the channel's throughput. Two levers to vary:
+
+1. **Target a busy, low-base-fee channel** (`--channel-to-jam-scid`): the per-HTLC opportunity cost
+   (hence sustaining cost) scales with the base fee of the target→receiver channel. Dust HTLCs on a
+   ~0 base-fee channel make slot jamming far cheaper than liquidity jamming for the same bucket.
+2. **Hold longer** (`--jam-duration`): the entry amortizes; cost/denied → 0 as the hold grows.
+
+Run the same command across `--reputation-algo {original,gradual}` (and any future algorithm) to
+compare whether the algorithm changes the entry/sustaining economics.
+
+## Worked example (the headline result)
+
+Against the `ln_slow_jam` network, targeting a high-revenue, low-base-fee channel:
+
+1. **Pick a target** the attacker can reach: node alias `2` (~83k sat/2w revenue) is adjacent to the
+   attacker receiver (alias `70`). Set `target.txt` to `2`.
+2. **Position the attacker** by adding two channels to `attacks/SlowSlotJam/attacktime_network.json`
+   (cloning an existing attacker-sender channel's shape): `25 ↔ 2` (build route) and `25 ↔ 13`
+   (jam route into node 2's busiest channel, `2 ↔ 13`, scid `570646534881280`, ~28.6k sat, 0 base).
+3. **Make the cost lever low-fee**: the held HTLCs exit via the target→receiver channel `2 → 70`,
+   so its base fee drives `htlc_risk`. Set `2 → 70` base fee `1000 → 1` in that same graph.
+   (Reputation does not need rebuilding — the attacker channels carry no peacetime traffic.)
+
+```sh
+ln-simln-jamming --network-dir networks/ln_slow_jam --attack-type slow-slot-jam \
+  --channel-to-jam-scid 570646534881280 --jam-duration 8w \
+  --clock-speedup 200 --target-reputation-percent 1
+```
+
+Result (8-week hold ≈ 4 revenue windows):
+
+| | sat |
+|---|---|
+| Attacker cost (entry 29.4k + sustaining ~0.5k over 17 cycles) | ~29,890 |
+| Honest revenue denied (98% of node 2's income) | ~51,021 |
+| **cost / denied** | **0.59** |
+| Target reputation pairs | 12/105 → 0/105 (wiped) |
+
+The same setup at `--jam-duration 1d` gives ratio ~32 (entry not amortized); 8 weeks → 0.59; the
+ratio keeps falling with duration. This is the thesis: on a busy, low-base-fee channel, a sustained
+slot jam costs a fraction of the revenue it denies — a cheap denial-of-service (the attacker's fees
+flow to the victim, so it isn't profit extraction, but service and reputation are destroyed).

--- a/ln-simln-jamming/scripts/setup_attack_network.py
+++ b/ln-simln-jamming/scripts/setup_attack_network.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Prepare a network's attack-time graph for a slot/liquidity jamming experiment.
+
+Idempotent and additive: it only touches the small `attacks/<Attack>/attacktime_network.json`
+(creating it from the SlowJam template if absent) and never modifies the peacetime graph,
+`target.txt`, or the (large) traffic/reputation files. Re-running is a no-op.
+
+It positions the attacker around a chosen target so the jam routes exist, and optionally lowers the
+base fee on the target->receiver channel (the channel whose fee drives the attacker's htlc_risk):
+
+  - add  sender  <-> target   (build route:  sender -> target -> receiver)
+  - add  sender  <-> peer     (jam route:    sender -> peer -> target -> receiver)
+  - set  target  -> receiver  base fee = --receiver-base-fee
+
+The peer is derived from --channel-to-jam-scid (the channel's endpoint that isn't the target).
+
+Usage (see the Makefile, which calls this for you):
+  setup_attack_network.py --network-dir networks/ln_slow_jam --attack SlowSlotJam \
+      --target-alias 2 --channel-to-jam-scid 570646534881280 \
+      --sender-alias 25 --receiver-alias 70 --receiver-base-fee 1
+"""
+import argparse
+import copy
+import json
+import shutil
+import sys
+from pathlib import Path
+
+
+def alias_map(channels):
+    m = {}
+    for c in channels:
+        for s in ("node_1", "node_2"):
+            m[c[s]["alias"]] = c[s]["pubkey"]
+    return m
+
+
+def channel_exists(channels, a, b):
+    for c in channels:
+        ends = {c["node_1"]["alias"], c["node_2"]["alias"]}
+        if ends == {a, b}:
+            return True
+    return False
+
+
+def synth_channel(scid, honest_alias, honest_pk, attacker_alias, attacker_pk):
+    """A generous attacker channel: large capacity, dust min, standard policy."""
+    side = lambda alias, pk, cltv, base: {
+        "pubkey": pk, "alias": alias, "max_htlc_count": 483,
+        "max_in_flight_msat": 50_000_000_000, "min_htlc_size_msat": 1,
+        "max_htlc_size_msat": 50_000_000_000, "cltv_expiry_delta": cltv,
+        "base_fee": base, "fee_rate_prop": 1,
+    }
+    return {
+        "scid": scid, "capacity_msat": 100_000_000_000,
+        "node_1": side(honest_alias, honest_pk, 40, 1000),
+        "node_2": side(attacker_alias, attacker_pk, 144, 1000),
+        "forward_only": True,
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--network-dir", required=True, type=Path)
+    ap.add_argument("--attack", required=True, help="attack dir name, e.g. SlowSlotJam")
+    ap.add_argument("--target-alias", required=True)
+    ap.add_argument("--channel-to-jam-scid", required=True, type=int)
+    ap.add_argument("--sender-alias", required=True)
+    ap.add_argument("--receiver-alias", required=True)
+    ap.add_argument("--receiver-base-fee", type=int, default=1,
+                    help="base fee (msat) to set on the target->receiver channel; low => cheap jam")
+    ap.add_argument("--receiver-prop-fee", type=int, default=0,
+                    help="proportional fee (ppm) on the target->receiver channel; 0 keeps the "
+                         "liquidity jam's entry buildable")
+    ap.add_argument("--template-attack", default="SlowJam",
+                    help="attack dir to clone attacktime_network.json/attacker.csv from if missing")
+    args = ap.parse_args()
+
+    attack_dir = args.network_dir / "attacks" / args.attack
+    graph_path = attack_dir / "attacktime_network.json"
+
+    # 1. Ensure the attack dir exists (clone the template attack's graph + attacker list).
+    if not graph_path.exists():
+        template_dir = args.network_dir / "attacks" / args.template_attack
+        if not template_dir.exists():
+            sys.exit(f"neither {attack_dir} nor template {template_dir} exists")
+        attack_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copy(template_dir / "attacktime_network.json", graph_path)
+        shutil.copy(template_dir / "attacker.csv", attack_dir / "attacker.csv")
+        print(f"created {attack_dir} from template {args.template_attack}")
+
+    doc = json.loads(graph_path.read_text())
+    g = doc["sim_network"]
+    aliases = alias_map(g)
+    for a in (args.target_alias, args.sender_alias, args.receiver_alias):
+        if a not in aliases:
+            sys.exit(f"alias {a} not found in {graph_path}")
+
+    # 2. Derive the peer (the channel_to_jam's endpoint that isn't the target).
+    target_pk = aliases[args.target_alias]
+    peer_alias = None
+    for c in g:
+        if c["scid"] == args.channel_to_jam_scid:
+            for s in ("node_1", "node_2"):
+                if c[s]["pubkey"] != target_pk:
+                    peer_alias = c[s]["alias"]
+    if peer_alias is None:
+        sys.exit(f"channel-to-jam scid {args.channel_to_jam_scid} not found / not a target channel")
+
+    # 3. Add attacker channels (idempotent): sender<->target (build) and sender<->peer (jam).
+    next_scid = max(c["scid"] for c in g) + 1
+    for honest in (args.target_alias, peer_alias):
+        if channel_exists(g, args.sender_alias, honest):
+            print(f"attacker channel {args.sender_alias}<->{honest} already present")
+            continue
+        g.append(synth_channel(next_scid, honest, aliases[honest],
+                               args.sender_alias, aliases[args.sender_alias]))
+        print(f"added attacker channel {args.sender_alias}<->{honest} (scid {next_scid})")
+        next_scid += 1
+
+    # 4. Set the target->receiver fee (base + proportional). The held protected HTLCs exit over this
+    #    channel, so its fee drives the attacker's htlc_risk (hence the one-time entry cost). The
+    #    proportional fee matters for the large liquidity-jam HTLCs; zeroing it keeps the liquidity
+    #    jam's entry buildable. Denied revenue is unaffected (it comes from the jammed channel).
+    set_fee = False
+    for c in g:
+        ends = {c["node_1"]["alias"], c["node_2"]["alias"]}
+        if ends == {args.target_alias, args.receiver_alias}:
+            for s in ("node_1", "node_2"):
+                if c[s]["alias"] == args.target_alias:
+                    if c[s]["base_fee"] != args.receiver_base_fee:
+                        print(f"set {args.target_alias}->{args.receiver_alias} base_fee "
+                              f"{c[s]['base_fee']} -> {args.receiver_base_fee}")
+                    c[s]["base_fee"] = args.receiver_base_fee
+                    c[s]["fee_rate_prop"] = args.receiver_prop_fee
+                    set_fee = True
+    if not set_fee:
+        sys.exit(f"no {args.target_alias}<->{args.receiver_alias} channel to set the fee on "
+                 f"(the receiver must already neighbour the target)")
+
+    graph_path.write_text(json.dumps(doc, indent=1))
+    print(f"experiment network ready: {graph_path} (target={args.target_alias}, peer={peer_alias})")
+
+
+if __name__ == "__main__":
+    main()

--- a/ln-simln-jamming/src/attacks/mod.rs
+++ b/ln-simln-jamming/src/attacks/mod.rs
@@ -9,6 +9,7 @@ use triggered::Listener;
 use crate::{accountable_from_records, records_from_signal, BoxError, NetworkReputation};
 
 pub mod sink;
+pub mod slot_liq_jam;
 pub mod slow_jam;
 pub mod utils;
 
@@ -19,6 +20,23 @@ pub struct AttackStatisitcs {
 
     /// The number of channels congestion jammed using [`reputation_interceptor::ChannelJammer`].
     pub congestion_jammed_channels: usize,
+
+    /// One-time fees (msat) the attacker paid to build the reputation needed to gain protected
+    /// access (the entry cost; scales with the target channel's revenue threshold).
+    pub entry_fees_paid_msat: u64,
+
+    /// Recurring fees (msat) the attacker paid to keep reputation above the (decaying) threshold
+    /// over the hold — the sustaining cost. Splitting this from the entry shows the "pay once, hold
+    /// cheaply" economics.
+    pub sustaining_fees_paid_msat: u64,
+
+    /// Total fees (msat) the attacker paid = entry + sustaining. Note these fees are paid *to the
+    /// target* (the attacker builds reputation by routing through it), so they partially offset the
+    /// target's revenue loss — see the summary's honest-revenue-denied figure.
+    pub total_fees_paid_msat: u64,
+
+    /// The number of reputation maintenance cycles (refills) performed during the hold.
+    pub refill_count: u64,
 }
 
 // Defines an attack that can be mounted against the simulation framework.

--- a/ln-simln-jamming/src/attacks/sink.rs
+++ b/ln-simln-jamming/src/attacks/sink.rs
@@ -308,6 +308,11 @@ where
             // We jam the target's channels in both directions.
             general_jammed_channels: self.target_channels.len() * 2,
             congestion_jammed_channels: 0,
+            // Sink does not build reputation, so no attacker spend to report.
+            entry_fees_paid_msat: 0,
+            sustaining_fees_paid_msat: 0,
+            total_fees_paid_msat: 0,
+            refill_count: 0,
         })
     }
 }

--- a/ln-simln-jamming/src/attacks/slot_liq_jam.rs
+++ b/ln-simln-jamming/src/attacks/slot_liq_jam.rs
@@ -1,0 +1,501 @@
+//! Protected-bucket jamming attacks that fill the target's protected resources and hold them,
+//! topping up reputation as it decays so the jam can be sustained.
+//!
+//! One configurable implementation covers three scenarios (the slow liquidity variant is already
+//! served by [`super::slow_jam`]):
+//! - **slow slot**: exhaust the protected *slot count* with many tiny HTLCs, held for the full
+//!   duration (~2 weeks).
+//! - **fast slot**: same slot fill, but held ~85s and repeated for up to 2 weeks (staying out of
+//!   the >90s zone where opportunity-cost penalties bite).
+//! - **fast liquidity**: exhaust the protected *liquidity* with a few large HTLCs (each bounded so
+//!   it stays individually admittable), held ~85s and repeated.
+//!
+//! All variants congest the general bucket first, then fill protected, and refill reputation only
+//! when it has decayed below the target's revenue threshold (paying exactly the deficit), tracking
+//! the fees paid so the attack's cost is reported.
+
+use crate::{
+    attacks::{
+        utils::{build_custom_route, build_reputation},
+        AttackStatisitcs, JammingAttack,
+    },
+    clock::InstantClock,
+    reputation_interceptor::{ChannelJammer, ReputationMonitor},
+    BoxError, NetworkReputation,
+};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use async_trait::async_trait;
+use bitcoin::secp256k1::PublicKey;
+use lightning::{ln::PaymentHash, routing::gossip::NetworkGraph};
+use ln_resource_mgr::forward_manager::{ForwardManagerParams, MAX_HTLC_SLOTS};
+use sim_cli::parsing::NetworkParser;
+use simln_lib::{
+    clock::{Clock, SimulationClock},
+    sim_node::{CustomRecords, ForwardingError, InterceptRequest, SimGraph, SimNode, WrappedLog},
+};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+    time::Duration,
+};
+use tokio::{select, sync::Mutex};
+use triggered::Listener;
+
+use super::utils::BuildReputationParams;
+
+type LdkNetworkGraph = NetworkGraph<Arc<WrappedLog>>;
+
+/// How the protected bucket is filled.
+#[derive(Clone, Copy, Debug)]
+pub enum FillMode {
+    /// Exhaust the protected *slot count*: send one HTLC of `htlc_msat` per protected slot (derived
+    /// from the reputation params, not hardcoded). Use a tiny amount, e.g. 1 sat, so slots run out
+    /// long before liquidity does.
+    Slots { htlc_msat: u64 },
+    /// Exhaust the protected *liquidity* with a single HTLC sized to the jammed channel's protected
+    /// liquidity bucket (derived from its capacity and the bucket portions, not hardcoded).
+    Liquidity,
+}
+
+/// Configuration that distinguishes the slot/liquidity and slow/fast variants.
+#[derive(Clone, Copy, Debug)]
+pub struct JamConfig {
+    pub fill: FillMode,
+    /// How long each fill is held in flight.
+    pub hold_time: Duration,
+    /// If true, release after `hold_time` and re-fill, repeating until `total_duration` elapses.
+    /// If false, a single fill is held for `hold_time` (the slow variant).
+    pub repeat: bool,
+    /// Overall attack window (only used when `repeat` is true).
+    pub total_duration: Duration,
+}
+
+/// Number of attempts to build the initial reputation (it can fall just short due to the random
+/// CLTV offset in route building; each attempt still settles a paying payment, so retrying
+/// converges).
+const BUILD_ATTEMPTS: usize = 8;
+
+/// Maximum size of a single HTLC used by the liquidity fill. The protected bucket is exhausted with
+/// several of these rather than one giant HTLC, so each stays individually admittable.
+const LIQ_HTLC_CHUNK_MSAT: u64 = 1_000_000_000;
+
+pub struct SlotLiqJam<R, J>
+where
+    R: ReputationMonitor + Send + Sync + 'static,
+    J: ChannelJammer + Send + Sync + 'static,
+{
+    clock: Arc<SimulationClock>,
+    target_pubkey: PublicKey,
+    attacker_sender: (String, PublicKey),
+    attacker_receiver: (String, PublicKey),
+    target_channels: HashMap<u64, PublicKey>,
+    channel_to_jam: (PublicKey, u64),
+    reputation_monitor: Arc<R>,
+    channel_jammer: Arc<J>,
+    network_graph: Arc<LdkNetworkGraph>,
+    jamming_payments: Arc<Mutex<HashSet<PaymentHash>>>,
+    reputation_params: ForwardManagerParams,
+    /// Capacity (msat) of the channel being jammed, used to size the liquidity fill.
+    jammed_capacity_msat: u64,
+    config: JamConfig,
+    // Stats. Entry is the one-time cost to gain protected access; sustaining is the recurring
+    // decay-driven maintenance — splitting them makes the "pay once, hold cheaply" economics
+    // visible in the results.
+    entry_fees: AtomicU64,
+    sustaining_fees: AtomicU64,
+    refill_count: AtomicU64,
+}
+
+impl<R, J> SlotLiqJam<R, J>
+where
+    R: ReputationMonitor + Send + Sync,
+    J: ChannelJammer + Send + Sync,
+{
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        clock: Arc<SimulationClock>,
+        network: &[NetworkParser],
+        target_pubkey: PublicKey,
+        attacker_sender: (String, PublicKey),
+        attacker_receiver: (String, PublicKey),
+        channel_to_jam: (PublicKey, u64),
+        reputation_monitor: Arc<R>,
+        channel_jammer: Arc<J>,
+        network_graph: Arc<LdkNetworkGraph>,
+        config: JamConfig,
+    ) -> Self {
+        let jammed_capacity_msat = network
+            .iter()
+            .find(|channel| u64::from(channel.scid) == channel_to_jam.1)
+            .map(|channel| channel.capacity_msat)
+            .unwrap_or(0);
+        Self {
+            clock,
+            target_pubkey,
+            attacker_sender,
+            attacker_receiver,
+            target_channels: HashMap::from_iter(network.iter().filter_map(|channel| {
+                if channel.node_1.pubkey == target_pubkey {
+                    Some((channel.scid.into(), channel.node_2.pubkey))
+                } else if channel.node_2.pubkey == target_pubkey {
+                    Some((channel.scid.into(), channel.node_1.pubkey))
+                } else {
+                    None
+                }
+            })),
+            channel_to_jam,
+            reputation_monitor,
+            channel_jammer,
+            network_graph,
+            jamming_payments: Arc::new(Mutex::new(HashSet::new())),
+            reputation_params: ForwardManagerParams::default(),
+            jammed_capacity_msat,
+            config,
+            entry_fees: AtomicU64::new(0),
+            sustaining_fees: AtomicU64::new(0),
+            refill_count: AtomicU64::new(0),
+        }
+    }
+
+    /// Number of protected-bucket slots on the jammed channel, derived from the reputation params:
+    /// `MAX_HTLC_SLOTS * (100 − general_portion − congestion_portion) / 100`. The slot jam aims to
+    /// occupy exactly this many, so it adapts to whatever bucket split the algo under test uses.
+    fn protected_slot_count(&self) -> usize {
+        let g = self.reputation_params.general_slot_portion as u16;
+        let c = self.reputation_params.congestion_slot_portion as u16;
+        (MAX_HTLC_SLOTS * (100 - g - c) / 100) as usize
+    }
+
+    /// Liquidity (msat) allocated to the protected bucket on the jammed channel:
+    /// `capacity × (100 − general_liquidity_portion − congestion_liquidity_portion) / 100`. Filling
+    /// this exhausts the protected liquidity, so it adapts to the channel under attack rather than
+    /// relying on a hardcoded amount.
+    fn protected_liquidity_msat(&self) -> u64 {
+        let g = self.reputation_params.general_liquidity_portion as u64;
+        let c = self.reputation_params.congestion_liquidity_portion as u64;
+        self.jammed_capacity_msat * (100 - g - c) / 100
+    }
+
+    /// The protected liquidity split into a handful of large HTLCs. A single HTLC big enough to fill
+    /// the whole bucket would need a prohibitive amount of reputation to admit, so the fill is spread
+    /// over several bounded HTLCs (each [`LIQ_HTLC_CHUNK_MSAT`] at most) that together exhaust the
+    /// bucket while staying within the protected slot count.
+    fn liquidity_htlcs(&self) -> Vec<u64> {
+        let total = self.protected_liquidity_msat();
+        if total == 0 {
+            return vec![];
+        }
+        let count = total
+            .div_ceil(LIQ_HTLC_CHUNK_MSAT)
+            .max(1)
+            .min(self.protected_slot_count() as u64);
+        let each = total / count;
+        vec![each; count as usize]
+    }
+
+    /// The protected-bucket HTLC amounts the attacker wants to keep alive (drives htlc_risk).
+    fn protected_htlcs(&self) -> Vec<u64> {
+        match self.config.fill {
+            FillMode::Slots { htlc_msat } => vec![htlc_msat; self.protected_slot_count()],
+            FillMode::Liquidity => self.liquidity_htlcs(),
+        }
+    }
+
+    /// Route used to build/refill reputation: target -> attacker_receiver (sender prepended by the
+    /// build helper). Does not traverse the channel being jammed, so it doesn't bump that channel's
+    /// revenue.
+    fn build_hops(&self) -> [PublicKey; 2] {
+        [self.target_pubkey, self.attacker_receiver.1]
+    }
+
+    /// Builds the attacker's initial reputation, retrying a few times since the one-shot fee can
+    /// fall just short of the sufficiency check.
+    async fn build_initial_reputation(
+        &self,
+        attacker_nodes: &HashMap<String, Arc<Mutex<SimNode<SimGraph, SimulationClock>>>>,
+    ) -> Result<(), BoxError> {
+        let attacker_node = attacker_nodes.get(&self.attacker_sender.0).ok_or(format!(
+            "node {} not found in attacker nodes list",
+            self.attacker_sender.0
+        ))?;
+        let hops = self.build_hops();
+        let mut last_err = None;
+        for attempt in 0..BUILD_ATTEMPTS {
+            let params = BuildReputationParams {
+                attacker_node: Arc::clone(attacker_node),
+                hops: &hops,
+                network_graph: &self.network_graph,
+                htlcs: self.protected_htlcs(),
+                target_channel: (self.target_pubkey, self.channel_to_jam.1),
+                reputation_monitor: Arc::clone(&self.reputation_monitor),
+                payment_hash: PaymentHash(rand::random()),
+                reputation_params: self.reputation_params,
+                clock: Arc::clone(&self.clock),
+                shutdown_listener: triggered::trigger().1,
+                fee_buffer: 5000,
+            };
+            match build_reputation(params).await {
+                Ok(fees) => {
+                    self.entry_fees.fetch_add(fees, Ordering::Relaxed);
+                    return Ok(());
+                }
+                Err(e) => {
+                    log::warn!("build_reputation attempt {attempt} did not reach threshold ({e})");
+                    last_err = Some(e);
+                }
+            }
+        }
+        Err(format!(
+            "could not build attacker reputation after {BUILD_ATTEMPTS} attempts: {}",
+            last_err.map(|e| e.to_string()).unwrap_or_default()
+        )
+        .into())
+    }
+
+    /// Maintains the attacker's reputation against the decaying average eroding it. Delegates to
+    /// [`build_reputation`], which reads the live reputation and pays exactly the deficit needed to
+    /// stay above `revenue + htlc_risk` (or only a small carrier fee when reputation is already
+    /// sufficient) — so the accumulated fees are the true decay-driven sustaining cost, with no
+    /// margin guesswork. Each maintenance cycle is counted in `refill_count`.
+    async fn refill(
+        &self,
+        attacker_nodes: &HashMap<String, Arc<Mutex<SimNode<SimGraph, SimulationClock>>>>,
+        shutdown_listener: Listener,
+    ) -> Result<(), BoxError> {
+        let attacker_node = attacker_nodes.get(&self.attacker_sender.0).ok_or(format!(
+            "node {} not found in attacker nodes list",
+            self.attacker_sender.0
+        ))?;
+        let hops = self.build_hops();
+        let params = BuildReputationParams {
+            attacker_node: Arc::clone(attacker_node),
+            hops: &hops,
+            network_graph: &self.network_graph,
+            htlcs: self.protected_htlcs(),
+            target_channel: (self.target_pubkey, self.channel_to_jam.1),
+            reputation_monitor: Arc::clone(&self.reputation_monitor),
+            payment_hash: PaymentHash(rand::random()),
+            reputation_params: self.reputation_params,
+            clock: Arc::clone(&self.clock),
+            shutdown_listener,
+            // Exact: build only the deficit, and only when reputation has actually fallen below the
+            // threshold (build_reputation returns 0 without paying when it is still sufficient).
+            fee_buffer: 0,
+        };
+        let fees = build_reputation(params).await?;
+        // Only a refill that actually paid counts: reputation often still covers the threshold, in
+        // which case build_reputation returns 0 without sending anything.
+        if fees > 0 {
+            self.sustaining_fees.fetch_add(fees, Ordering::Relaxed);
+            self.refill_count.fetch_add(1, Ordering::Relaxed);
+            log::info!("reputation maintenance cycle: paid {fees} msat");
+        }
+        Ok(())
+    }
+
+    /// Sends one round of protected-bucket fill payments (held by `intercept_attacker_receive`).
+    /// Returns the number of HTLCs successfully sent.
+    async fn send_fill(
+        &self,
+        attacker_nodes: &HashMap<String, Arc<Mutex<SimNode<SimGraph, SimulationClock>>>>,
+    ) -> Result<usize, BoxError> {
+        let sender = attacker_nodes.get(&self.attacker_sender.0).ok_or(format!(
+            "node {} not found in attacker nodes list",
+            self.attacker_sender.0
+        ))?;
+        let hops = vec![
+            self.channel_to_jam.0,
+            self.target_pubkey,
+            self.attacker_receiver.1,
+        ];
+        let (count, amt) = match self.config.fill {
+            FillMode::Slots { htlc_msat } => (self.protected_slot_count(), htlc_msat),
+            FillMode::Liquidity => {
+                let htlcs = self.liquidity_htlcs();
+                (htlcs.len(), htlcs.first().copied().unwrap_or(0))
+            }
+        };
+
+        let mut sent = 0;
+        for _ in 0..count {
+            let route = match build_custom_route(
+                &self.attacker_sender.1,
+                amt,
+                &hops,
+                &self.network_graph,
+            ) {
+                Ok(route) => route,
+                Err(e) => {
+                    log::warn!("could not build fill route: {}", e.err);
+                    continue;
+                }
+            };
+            let payment_hash = PaymentHash(rand::random());
+            self.jamming_payments.lock().await.insert(payment_hash);
+            match sender
+                .lock()
+                .await
+                .send_to_route(route, payment_hash, None)
+                .await
+            {
+                Ok(_) => sent += 1,
+                Err(e) => {
+                    self.jamming_payments.lock().await.remove(&payment_hash);
+                    log::warn!("fill payment send failed (slot/liquidity likely full): {e}");
+                }
+            }
+        }
+        Ok(sent)
+    }
+}
+
+#[async_trait]
+impl<R, J> JammingAttack for SlotLiqJam<R, J>
+where
+    R: ReputationMonitor + Send + Sync,
+    J: ChannelJammer + Send + Sync,
+{
+    fn validate(&self) -> Result<(), BoxError> {
+        // Attacker receiver must have a channel with the target.
+        self.target_channels
+            .iter()
+            .find(|chan| self.attacker_receiver.1 == *chan.1)
+            .ok_or(format!(
+                "Target does not have a channel with attacker receiver {}",
+                self.attacker_receiver.1
+            ))?;
+
+        // The channel we want to jam must belong to the target's channel set.
+        let target_peer_pubkey =
+            self.target_channels
+                .get(&self.channel_to_jam.1)
+                .ok_or(format!(
+                    "channel {} to jam is not part of target's channels",
+                    self.channel_to_jam.1
+                ))?;
+        if *target_peer_pubkey != self.channel_to_jam.0 {
+            return Err("peer in channel to jam does not match".into());
+        }
+
+        Ok(())
+    }
+
+    /// Reputation-building/refill payments (not in `jamming_payments`) are forwarded so they
+    /// settle; fill payments are held for `hold_time` then failed.
+    async fn intercept_attacker_receive(
+        &self,
+        req: InterceptRequest,
+    ) -> Result<Result<CustomRecords, ForwardingError>, BoxError> {
+        if !self
+            .jamming_payments
+            .lock()
+            .await
+            .contains(&req.payment_hash)
+        {
+            return Ok(Ok(req.incoming_custom_records));
+        }
+
+        select! {
+            _ = req.shutdown_listener.clone() => Ok(Err(ForwardingError::InterceptorError(
+                "shutdown signal received".to_string(),
+            ))),
+            _ = self.clock.sleep(self.config.hold_time) => {
+                self.jamming_payments.lock().await.remove(&req.payment_hash);
+                Ok(Err(ForwardingError::InterceptorError(
+                    "failing from jamming interceptor".into(),
+                )))
+            }
+        }
+    }
+
+    async fn run_attack(
+        &self,
+        _start_reputation: NetworkReputation,
+        attacker_nodes: HashMap<String, Arc<Mutex<SimNode<SimGraph, SimulationClock>>>>,
+        shutdown_listener: Listener,
+    ) -> Result<(), BoxError> {
+        let start = InstantClock::now(&*self.clock);
+
+        // Gain protected access, then congest the cheaper buckets.
+        self.build_initial_reputation(&attacker_nodes).await?;
+        self.channel_jammer
+            .jam_general_resources(&self.target_pubkey, self.channel_to_jam.1)
+            .await?;
+        self.channel_jammer
+            .jam_congestion_resources(&self.target_pubkey, self.channel_to_jam.1)
+            .await?;
+
+        let mut round = 0u64;
+        loop {
+            // Keep reputation above the threshold before (re)filling.
+            if let Err(e) = self
+                .refill(&attacker_nodes, shutdown_listener.clone())
+                .await
+            {
+                log::warn!("refill on round {round} failed (continuing): {e}");
+            }
+
+            let sent = self.send_fill(&attacker_nodes).await?;
+            log::info!(
+                "round {round}: sent {sent} jamming HTLC(s), holding for {:?}",
+                self.config.hold_time
+            );
+
+            // Hold for the configured time, refilling reputation periodically as the decaying
+            // average erodes it. The revenue threshold decays too (the jammed channel earns
+            // nothing), but we top up whenever reputation would fall within the margin so the jam
+            // is never evicted — this is the decay-driven sustaining cost. +10s buffer so the
+            // interceptor releases before the next round.
+            let hold_end =
+                InstantClock::now(&*self.clock) + self.config.hold_time + Duration::from_secs(10);
+            let check_interval = (self.reputation_params.reputation_params.revenue_window / 4)
+                .max(Duration::from_secs(1));
+            let mut interrupted = false;
+            loop {
+                let now = InstantClock::now(&*self.clock);
+                if now >= hold_end {
+                    break;
+                }
+                let nap = (hold_end - now).min(check_interval);
+                select! {
+                    _ = shutdown_listener.clone() => { interrupted = true; break; }
+                    _ = self.clock.sleep(nap) => {}
+                }
+                if let Err(e) = self
+                    .refill(&attacker_nodes, shutdown_listener.clone())
+                    .await
+                {
+                    log::warn!("decay refill on round {round} failed (continuing): {e}");
+                }
+            }
+            if interrupted {
+                break;
+            }
+
+            round += 1;
+            if !self.config.repeat {
+                break;
+            }
+            if InstantClock::now(&*self.clock).duration_since(start) >= self.config.total_duration {
+                log::info!("reached total attack duration after {round} round(s)");
+                break;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn attack_statistics(&self) -> Result<AttackStatisitcs, BoxError> {
+        let entry = self.entry_fees.load(Ordering::Relaxed);
+        let sustaining = self.sustaining_fees.load(Ordering::Relaxed);
+        Ok(AttackStatisitcs {
+            general_jammed_channels: 1,
+            congestion_jammed_channels: 1,
+            entry_fees_paid_msat: entry,
+            sustaining_fees_paid_msat: sustaining,
+            total_fees_paid_msat: entry + sustaining,
+            refill_count: self.refill_count.load(Ordering::Relaxed),
+        })
+    }
+}

--- a/ln-simln-jamming/src/attacks/slow_jam.rs
+++ b/ln-simln-jamming/src/attacks/slow_jam.rs
@@ -137,6 +137,7 @@ where
             reputation_params: self.reputation_params,
             clock: Arc::clone(&self.clock),
             shutdown_listener: trigger().1,
+            fee_buffer: 5000,
         };
         let fees_paid = build_reputation(build_rep_params).await?;
         Ok(fees_paid)
@@ -424,6 +425,11 @@ where
         Ok(AttackStatisitcs {
             general_jammed_channels: 1,
             congestion_jammed_channels: 1,
+            // Slow-jam builds reputation once up front and does not track that spend here.
+            entry_fees_paid_msat: 0,
+            sustaining_fees_paid_msat: 0,
+            total_fees_paid_msat: 0,
+            refill_count: 0,
         })
     }
 }

--- a/ln-simln-jamming/src/attacks/utils.rs
+++ b/ln-simln-jamming/src/attacks/utils.rs
@@ -59,6 +59,9 @@ pub struct BuildReputationParams<'a, R: ReputationMonitor> {
     pub reputation_params: ForwardManagerParams,
     pub clock: Arc<SimulationClock>,
     pub shutdown_listener: Listener,
+    /// Reputation to build beyond the bare `revenue + htlc_risk` threshold. 0 = exact (pay only the
+    /// deficit); a small margin makes initial entry robust to the random CLTV offset in routing.
+    pub fee_buffer: u32,
 }
 
 /// Helper to build outgoing reputation towards the attacker with a specific target_channel.
@@ -126,8 +129,16 @@ pub async fn build_reputation<R: ReputationMonitor>(
         target_channel.0,
         current_target_revenue,
         current_attacker_reputation,
-        5000,
+        params.fee_buffer,
     );
+
+    // Gated, exact refill: if reputation already covers `revenue + htlc_risk` (+ buffer) the deficit
+    // is zero, so there is nothing to build — don't send a carrier payment just to pay route fees.
+    // This is what keeps maintenance free when the held HTLCs accrue no penalty (fast 85s holds);
+    // when reputation has genuinely decayed below the threshold, we pay exactly the deficit.
+    if total_fee == 0 {
+        return Ok(0);
+    }
 
     let total_fees_paid = total_fee + route.get_total_fees();
     for path in route.paths.iter_mut() {
@@ -525,6 +536,7 @@ mod tests {
             reputation_params: ForwardManagerParams::default(),
             clock: Arc::clone(&clock),
             shutdown_listener: shutdown.1.clone(),
+            fee_buffer: 5000,
         };
 
         let _ = build_reputation(build_rep_params).await.unwrap();

--- a/ln-simln-jamming/src/bin/reputation_builder.rs
+++ b/ln-simln-jamming/src/bin/reputation_builder.rs
@@ -14,8 +14,8 @@ use ln_simln_jamming::{
     analysis::BatchForwardWriter,
     clock::InstantClock,
     parsing::{
-        get_history_for_bootstrap, history_from_file, parse_duration, AttackType, NetworkParams,
-        NetworkType, ReputationParams,
+        boost_history, get_history_for_bootstrap, history_from_file, parse_duration, AttackType,
+        NetworkParams, NetworkType, ReputationParams,
     },
     reputation_interceptor::{BootstrapRecords, ReputationInterceptor, ReputationMonitor},
     BoxError,
@@ -41,6 +41,12 @@ struct Cli {
     /// for, expressed as human readable values (eg: 1w, 3d).
     #[arg(long, value_parser = parse_duration, requires = "attack_type")]
     pub attacker_bootstrap: Option<Duration>,
+
+    /// Loop ("boost") a short traffic file to fill the reputation window instead of requiring a
+    /// full-length file on disk. Reads the whole file and tiles it (with forward-shifted, monotonic
+    /// timestamps) up to the reputation window — the window itself is unchanged. Off by default.
+    #[arg(long)]
+    pub allow_boost: bool,
 }
 
 #[tokio::main]
@@ -63,11 +69,21 @@ async fn main() -> Result<(), BoxError> {
     let target_pubkey = network.target().1;
     let traffic_file = network.traffic_file();
 
-    let unfiltered_history = history_from_file(
-        &traffic_file,
-        Some(forward_params.reputation_params.reputation_window()),
-    )
-    .await?;
+    let reputation_window = forward_params.reputation_params.reputation_window();
+    let unfiltered_history = if cli.allow_boost {
+        // Read the whole (short) file and tile it to fill the reputation window.
+        let history = history_from_file(&traffic_file, None).await?;
+        let boosted = boost_history(history, reputation_window);
+        log::info!(
+            "Boosted {:?} to fill the {:?} reputation window: {} forwards",
+            traffic_file,
+            reputation_window,
+            boosted.len(),
+        );
+        boosted
+    } else {
+        history_from_file(&traffic_file, Some(reputation_window)).await?
+    };
 
     // Filter bootstrap records if attacker alias and bootstrap provided.
     // Only add up revenue if attacker bootstrap is specified.

--- a/ln-simln-jamming/src/main.rs
+++ b/ln-simln-jamming/src/main.rs
@@ -47,11 +47,14 @@ async fn main() -> Result<(), BoxError> {
         .init()
         .unwrap();
 
-    let network = NetworkType::new(
+    let mut network = NetworkType::new(
         &cli.network,
         Some(cli.attack_type.clone()),
         cli.attacker_bootstrap,
     )?;
+    if let Some(alias) = &cli.target_alias {
+        network.override_target(alias)?;
+    }
     let (target_alias, target_pubkey) = network.target();
     let attackers = network.attackers();
     let attacker_pubkeys: Vec<PublicKey> = attackers.iter().map(|a| a.1).collect();

--- a/ln-simln-jamming/src/main.rs
+++ b/ln-simln-jamming/src/main.rs
@@ -92,8 +92,13 @@ async fn main() -> Result<(), BoxError> {
     let now = InstantClock::now(&*clock);
 
     // Create a writer to store results for nodes that we care about.
+    // Label groups this experiment's results; defaults to the reputation algorithm name.
+    let label = cli
+        .label
+        .clone()
+        .unwrap_or_else(|| cli.reputation_params.reputation_algo.name().to_string());
     let results_dir = network
-        .results_dir(Clock::now(&*clock))
+        .results_dir(Clock::now(&*clock), &label)
         .ok_or("results dir none for attack")?;
     if !results_dir.exists() {
         fs::create_dir_all(&results_dir)?;

--- a/ln-simln-jamming/src/main.rs
+++ b/ln-simln-jamming/src/main.rs
@@ -474,6 +474,47 @@ fn write_simulation_summary(
         "Attacker congestion jammed {} edges (directional)",
         attack_stats.congestion_jammed_channels,
     )?;
+    // The attacker builds reputation by routing *through* the target, so its fees are paid to the
+    // target and inflate `Simulation revenue`. Adding them back recovers the honest revenue denied.
+    let honest_revenue_denied = (revenue.peacetime_revenue_msat as i128
+        - revenue.simulation_revenue_msat as i128
+        + attack_stats.total_fees_paid_msat as i128)
+        .max(0) as u128;
+    let secs = revenue.runtime.as_secs();
+    // Absolute figures only (no ratios): how long the jam ran, what the target would have earned
+    // honestly over that window, how much of that the jam denied, and what the attacker paid —
+    // split into the one-time entry (gain protected access) and the ongoing maintenance.
+    writeln!(
+        writer,
+        "Attack total duration (seconds): {} ({:.2} days)",
+        secs,
+        secs as f64 / 86_400.0,
+    )?;
+    writeln!(
+        writer,
+        "Honest revenue the target earns over this duration (msat): {}",
+        revenue.peacetime_revenue_msat,
+    )?;
+    writeln!(
+        writer,
+        "Honest revenue denied over this duration (msat): {}",
+        honest_revenue_denied,
+    )?;
+    writeln!(
+        writer,
+        "Attacker total cost (msat): {}",
+        attack_stats.total_fees_paid_msat,
+    )?;
+    writeln!(
+        writer,
+        "  one-time entry cost (gain protected access) (msat): {}",
+        attack_stats.entry_fees_paid_msat,
+    )?;
+    writeln!(
+        writer,
+        "  sustaining cost (maintain the jam, {} refill(s)) (msat): {}",
+        attack_stats.refill_count, attack_stats.sustaining_fees_paid_msat,
+    )?;
     writer.flush()?;
 
     Ok(())

--- a/ln-simln-jamming/src/parsing.rs
+++ b/ln-simln-jamming/src/parsing.rs
@@ -1,4 +1,5 @@
 use crate::attacks::sink::SinkAttack;
+use crate::attacks::slot_liq_jam::{FillMode, JamConfig, SlotLiqJam};
 use crate::attacks::slow_jam::SlowJam;
 use crate::attacks::JammingAttack;
 use crate::reputation_interceptor::{
@@ -49,6 +50,9 @@ pub const DEFAULT_REPUTATION_MARGIN_EXIPRY: &str = "200";
 /// The default batch size for writing results to disk.
 pub const DEFAULT_RESULT_BATCH_SIZE: &str = "500";
 
+
+
+
 #[derive(Clone, Parser)]
 pub struct ReputationParams {
     /// The window over which the value of a link's revenue to our node is calculated.
@@ -58,6 +62,7 @@ pub struct ReputationParams {
     /// The multiplier applied to revenue_window_seconds to get the duration over which reputation is bootstrapped.
     #[arg(long)]
     pub reputation_multiplier: Option<u8>,
+
 }
 
 impl From<ReputationParams> for ForwardManagerParams {
@@ -177,8 +182,9 @@ impl NetworkType {
         }
     }
 
-    /// Returns a directory to write simulation results to, if appropriate for network type,
-    /// namespacing by the runtime provided.
+    /// Returns a directory to write simulation results to, if appropriate for network type:
+    /// `results/{Attack}/{label}/{seconds_since_epoch}`. The label groups runs of the same
+    /// experiment (e.g. by reputation algorithm) for easier comparison.
     pub fn results_dir(&self, now: SystemTime) -> Option<PathBuf> {
         match self {
             NetworkType::Peacetime(_) => None,
@@ -202,6 +208,7 @@ impl NetworkType {
             | NetworkType::BootstrapAttackTime(p, _, _) => p.target.clone(),
         }
     }
+
 
     /// Returns the public keys of attackers in our network, if any.
     pub fn attackers(&self) -> &[(String, PublicKey)] {
@@ -430,8 +437,23 @@ pub struct Cli {
     #[arg(long, default_value = DEFAULT_RESULT_BATCH_SIZE)]
     pub result_batch_size: u16,
 
+
+    /// scid of the target channel to jam (the slot/liquidity attacks). The peer is derived from the
+    /// graph as the channel's endpoint that isn't the target. Defaults to the original slow-jam
+    /// channel; set it to re-point the attack at a different (e.g. higher-revenue) target channel.
+    #[arg(long)]
+    pub channel_to_jam_scid: Option<u64>,
+
+    /// How long to sustain the slot/liquidity jam (eg `4w`, `6months`). For the slow variants this
+    /// is the single hold; for the fast variants it's the total window over which short holds are
+    /// repeated. Holding for several revenue windows is how the one-time entry cost amortizes
+    /// below the (accumulating) revenue denied. Defaults to 2 weeks.
+    #[arg(long, value_parser = parse_duration)]
+    pub jam_duration: Option<Duration>,
+
     #[command(flatten)]
     pub reputation_params: ReputationParams,
+
 
     #[clap(long, default_value = "debug")]
     pub log_level: LevelFilter,
@@ -441,6 +463,12 @@ pub struct Cli {
 pub enum AttackType {
     Sink,
     SlowJam,
+    /// Slow slot jamming: fill the protected bucket with many tiny HTLCs (exhaust slots), hold ~2w.
+    SlowSlotJam,
+    /// Fast slot jamming: same slot fill, held ~85s and repeated for up to 2w.
+    FastSlotJam,
+    /// Fast liquidity jamming: a few large HTLCs exhausting protected liquidity, held ~85s, repeated.
+    FastLiqJam,
     // NOTE: add your attack that you want to run here.
 }
 
@@ -524,6 +552,88 @@ where
                 Arc::clone(&reputation_monitor),
                 Arc::clone(&channel_jammer),
                 network_graph,
+            ));
+
+            Ok(attack)
+        }
+        AttackType::SlowSlotJam | AttackType::FastSlotJam | AttackType::FastLiqJam => {
+            // All three reuse the slow-jam topology: attacker receiver alias 70, sender alias 25.
+            let attackers = network.attackers();
+            let attacker_receiver = attackers
+                .iter()
+                .find(|a| a.0 == "70")
+                .ok_or("Required attacker receiver with alias 70 not found")?;
+            let attacker_sender = attackers
+                .iter()
+                .find(|a| a.0 == "25")
+                .ok_or("Required attacker sender with alias 25 not found")?;
+
+            // Channel to jam: default to the original slow-jam channel, or take --channel-to-jam-scid.
+            // Derive the peer as the endpoint of that channel that isn't the target.
+            let channel_to_jam_scid = cli.channel_to_jam_scid.unwrap_or(348545186070528);
+            let target_pubkey = network.target().1;
+            let target_peer_pubkey = sim_network
+                .iter()
+                .find(|c| u64::from(c.scid) == channel_to_jam_scid)
+                .and_then(|c| {
+                    if c.node_1.pubkey == target_pubkey {
+                        Some(c.node_2.pubkey)
+                    } else if c.node_2.pubkey == target_pubkey {
+                        Some(c.node_1.pubkey)
+                    } else {
+                        None
+                    }
+                })
+                .ok_or(format!(
+                    "channel-to-jam scid {channel_to_jam_scid} is not a channel of the target"
+                ))?;
+            let channel_to_jam = (target_peer_pubkey, channel_to_jam_scid);
+            let network_graph = network_graph(sim_network.clone())?;
+
+            // Two weeks as 2016 blocks * 10 minutes (matches slow_jam's hold); overridable via
+            // --jam-duration so the jam can be sustained across several revenue windows.
+            let two_weeks = Duration::from_secs(2016 * 10 * 60);
+            let jam_duration = cli.jam_duration.unwrap_or(two_weeks);
+            // Fast variants hold just under the 90s resolution period so opportunity-cost penalties
+            // don't accrue, then repeat.
+            let fast_hold = Duration::from_secs(85);
+
+            let config = match network
+                .attack_type()
+                .ok_or("attack type must be set for simulation")?
+            {
+                AttackType::SlowSlotJam => JamConfig {
+                    fill: FillMode::Slots { htlc_msat: 1_000 },
+                    hold_time: jam_duration,
+                    repeat: false,
+                    total_duration: jam_duration,
+                },
+                AttackType::FastSlotJam => JamConfig {
+                    fill: FillMode::Slots { htlc_msat: 1_000 },
+                    hold_time: fast_hold,
+                    repeat: true,
+                    total_duration: jam_duration,
+                },
+                AttackType::FastLiqJam => JamConfig {
+                    fill: FillMode::Liquidity,
+                    hold_time: fast_hold,
+                    repeat: true,
+                    total_duration: jam_duration,
+                },
+                _ => unreachable!("outer match guarantees a slot/liquidity variant"),
+            };
+
+            let attack = Arc::new(SlotLiqJam::new(
+                Arc::clone(&clock),
+                sim_network,
+                network.target().1,
+                attacker_sender.clone(),
+                attacker_receiver.clone(),
+                channel_to_jam,
+                Arc::clone(&reputation_monitor),
+                Arc::clone(&channel_jammer),
+                network_graph,
+                config,
             ));
 
             Ok(attack)
@@ -755,6 +865,7 @@ pub async fn history_from_file(
 
     Ok(forwards)
 }
+
 
 pub fn reputation_snapshot_from_file(
     file_path: &PathBuf,

--- a/ln-simln-jamming/src/parsing.rs
+++ b/ln-simln-jamming/src/parsing.rs
@@ -13,7 +13,7 @@ use csv::{ReaderBuilder, StringRecord};
 use humantime::Duration as HumanDuration;
 use lightning::routing::gossip::NetworkGraph;
 use ln_resource_mgr::forward_manager::ForwardManagerParams;
-use ln_resource_mgr::ChannelSnapshot;
+use ln_resource_mgr::{ChannelSnapshot, ReputationAlgo};
 use log::LevelFilter;
 use serde::{Deserialize, Serialize};
 use sim_cli::parsing::NetworkParser;
@@ -50,8 +50,40 @@ pub const DEFAULT_REPUTATION_MARGIN_EXIPRY: &str = "200";
 /// The default batch size for writing results to disk.
 pub const DEFAULT_RESULT_BATCH_SIZE: &str = "500";
 
+/// CLI selector for the reputation scoring algorithm. Maps to [`ReputationAlgo`]; add a variant here
+/// (and the match arm) when a new named algorithm is added in ln-resource-mgr.
+#[derive(Clone, Copy, Debug, ValueEnum)]
+pub enum ReputationAlgoArg {
+    /// Pre-existing stepwise opportunity cost.
+    Original,
+    /// Gradual opportunity cost (bolts#1280 / jam-ln#119): linear above the resolution period, zero
+    /// below, no stair-steps.
+    Gradual,
+    /// Ramp opportunity cost: free below a 5s grace, linear up to one fee at the resolution period,
+    /// then `fee × hold/period` above it. Charges sub-period holds, closing the fast-jam window.
+    Ramp,
+}
 
+impl ReputationAlgoArg {
+    /// Canonical name (used as the default experiment label).
+    pub fn name(&self) -> &'static str {
+        match self {
+            ReputationAlgoArg::Original => "original",
+            ReputationAlgoArg::Gradual => "gradual",
+            ReputationAlgoArg::Ramp => "ramp",
+        }
+    }
+}
 
+impl From<ReputationAlgoArg> for ReputationAlgo {
+    fn from(arg: ReputationAlgoArg) -> Self {
+        match arg {
+            ReputationAlgoArg::Original => ReputationAlgo::Original,
+            ReputationAlgoArg::Gradual => ReputationAlgo::Gradual,
+            ReputationAlgoArg::Ramp => ReputationAlgo::Ramp,
+        }
+    }
+}
 
 #[derive(Clone, Parser)]
 pub struct ReputationParams {
@@ -63,6 +95,10 @@ pub struct ReputationParams {
     #[arg(long)]
     pub reputation_multiplier: Option<u8>,
 
+    /// The reputation scoring algorithm to use. Defaults to `gradual` (the behaviour on `master`);
+    /// pass `original` to compare against the pre-existing stepwise opportunity cost.
+    #[arg(long, value_enum, default_value_t = ReputationAlgoArg::Gradual)]
+    pub reputation_algo: ReputationAlgoArg,
 }
 
 impl From<ReputationParams> for ForwardManagerParams {
@@ -74,6 +110,7 @@ impl From<ReputationParams> for ForwardManagerParams {
         if let Some(multiplier) = cli.reputation_multiplier {
             forward_params.reputation_params.reputation_multiplier = multiplier;
         }
+        forward_params.reputation_params.algo = cli.reputation_algo.into();
         forward_params
     }
 }
@@ -185,7 +222,7 @@ impl NetworkType {
     /// Returns a directory to write simulation results to, if appropriate for network type:
     /// `results/{Attack}/{label}/{seconds_since_epoch}`. The label groups runs of the same
     /// experiment (e.g. by reputation algorithm) for easier comparison.
-    pub fn results_dir(&self, now: SystemTime) -> Option<PathBuf> {
+    pub fn results_dir(&self, now: SystemTime, label: &str) -> Option<PathBuf> {
         match self {
             NetworkType::Peacetime(_) => None,
             NetworkType::AttackTime(_, a) | NetworkType::BootstrapAttackTime(_, a, _) => {
@@ -194,6 +231,7 @@ impl NetworkType {
                 Some(
                     PathBuf::from("results")
                         .join(format!("{:?}", a.attack))
+                        .join(label)
                         .join(sec_since_epoch.to_string()),
                 )
             }
@@ -454,6 +492,10 @@ pub struct Cli {
     #[command(flatten)]
     pub reputation_params: ReputationParams,
 
+    /// Optional label for this experiment. Results are written to
+    /// `results/{Attack}/{label}/{timestamp}`. Defaults to the reputation algorithm name.
+    #[arg(long)]
+    pub label: Option<String>,
 
     #[clap(long, default_value = "debug")]
     pub log_level: LevelFilter,

--- a/ln-simln-jamming/src/parsing.rs
+++ b/ln-simln-jamming/src/parsing.rs
@@ -247,6 +247,18 @@ impl NetworkType {
         }
     }
 
+    /// Overrides the target node (chosen from `target.txt`) by alias, resolved against the peacetime
+    /// graph. Lets a run pick its target at runtime without editing shared network files.
+    pub fn override_target(&mut self, alias: &str) -> Result<(), BoxError> {
+        let peacetime = match self {
+            NetworkType::Peacetime(p)
+            | NetworkType::AttackTime(p, _)
+            | NetworkType::BootstrapAttackTime(p, _, _) => p,
+        };
+        let pubkey = find_pubkey_by_alias(alias, &peacetime.graph)?;
+        peacetime.target = (alias.to_owned(), pubkey);
+        Ok(())
+    }
 
     /// Returns the public keys of attackers in our network, if any.
     pub fn attackers(&self) -> &[(String, PublicKey)] {
@@ -475,6 +487,10 @@ pub struct Cli {
     #[arg(long, default_value = DEFAULT_RESULT_BATCH_SIZE)]
     pub result_batch_size: u16,
 
+    /// Alias of the node to attack, overriding `target.txt`. Lets experiments pick a target at
+    /// runtime without mutating shared network data (and makes switching targets a flag).
+    #[arg(long)]
+    pub target_alias: Option<String>,
 
     /// scid of the target channel to jam (the slot/liquidity attacks). The peer is derived from the
     /// graph as the channel's endpoint that isn't the target. Defaults to the original slow-jam
@@ -908,6 +924,44 @@ pub async fn history_from_file(
     Ok(forwards)
 }
 
+/// Tiles a short window of bootstrap forwards (the "loopback"/boost) so it spans at least `target`
+/// of wall time, without writing the duplicated data to disk. Lets a short traffic file bootstrap a
+/// full-length reputation window — the protocol's revenue/reputation windows are unchanged; only the
+/// *input data* is repeated to cover them.
+///
+/// Each repetition is shifted forward by the source's full span so timestamps stay strictly
+/// increasing across tile seams (the decaying-average reputation update rejects out-of-order
+/// timestamps). Returns the input unchanged if it already covers `target` (or is empty).
+pub fn boost_history(forwards: Vec<BootstrapForward>, target: Duration) -> Vec<BootstrapForward> {
+    let target_ns = target.as_nanos() as u64;
+    let min_added = match forwards.iter().map(|f| f.added_ns).min() {
+        Some(v) => v,
+        None => return forwards,
+    };
+    let max_settled = forwards
+        .iter()
+        .map(|f| f.settled_ns)
+        .max()
+        .unwrap_or(min_added);
+    let span = max_settled.saturating_sub(min_added);
+    if span == 0 || span >= target_ns {
+        return forwards;
+    }
+
+    let tiles = target_ns.div_ceil(span);
+    let mut boosted = Vec::with_capacity(forwards.len() * tiles as usize);
+    for tile in 0..tiles {
+        // +tile keeps seams strictly monotonic when a forward sits exactly on the boundary.
+        let shift = tile.saturating_mul(span).saturating_add(tile);
+        for f in &forwards {
+            let mut copy = f.clone();
+            copy.added_ns += shift;
+            copy.settled_ns += shift;
+            boosted.push(copy);
+        }
+    }
+    boosted
+}
 
 pub fn reputation_snapshot_from_file(
     file_path: &PathBuf,

--- a/ln-simln-jamming/src/reputation_interceptor.rs
+++ b/ln-simln-jamming/src/reputation_interceptor.rs
@@ -621,7 +621,8 @@ mod tests {
     };
     use ln_resource_mgr::{
         AccountableSignal, AllocationCheck, ChannelSnapshot, ForwardResolution, ForwardingOutcome,
-        HtlcRef, ProposedForward, ReputationError, ReputationManager, ReputationParams,
+        HtlcRef, ProposedForward, ReputationAlgo, ReputationError, ReputationManager,
+        ReputationParams,
     };
     use mockall::mock;
     use sim_cli::parsing::NetworkParser;
@@ -928,6 +929,7 @@ mod tests {
                 reputation_multiplier: 60,
                 resolution_period: Duration::from_secs(90),
                 expected_block_speed: None,
+                algo: ReputationAlgo::Original,
             },
             general_slot_portion: 30,
             general_liquidity_portion: 30,


### PR DESCRIPTION
 ## New jamming profiles and a reputation fix for sub‑period holds (<=90s)

  Adds three protected‑bucket jamming attacks, a pluggable opportunity‑cost framework, and a new algorithm that attempts to close the gap they exploit.

  Attacks (`--attack-type`):
  - `slow‑slot`: fill the protected slot bucket with dust HTLCs, hold for weeks.
  - `fast‑slot`: same fill, but hold ~85s, cancel, repeat.
  - `fast‑liq`: exhaust protected liquidity with a few large HTLCs, ~85s, repeat.

  Why they work: the gradual opportunity cost `max(0, (hold − period)/period)·fee` is 0 for any hold below the 90s resolution period. So an attacker holding at 85s cancels and re‑jams indefinitely with zero reputation penalty: the jam is essentially free to sustain. 

> A 3‑month slow‑slot run denies ~98% of a channel's revenue at ~0.5× the attacker's cost, which is almost entirely the one‑time entry.

Run it locally: one command, generates traffic + reputation from scratch:
```
  make slow-slot-jam        # also: fast-slot-jam, fast-liq-jam
```

  The new algo `Ramp`: a hold ≤90s should not be free. Ramp charges nothing below a 5s grace, ramps linearly to one full fee at the period, then continues at the gradual rate: so sustained sub‑period jamming bleeds reputation and costs.

Selectable via `--reputation-algo {original,gradual,ramp}`; default behaviour unchanged.

### Notes

- This PR is a placeholder for experimenting: tweaking and re-running experiments takes multiple hours. When demonstrating attacker cost vs denied revenue sometimes you have to go beyond 2w as break-even happens at a later point. (~7-8h of sims).

- I will keep this as draft, then share numbers for all attacks vs original algo & all attacks vs `Ramp` algo (mitigates fast variants).

- Instead of creating a lot of small PRs that are hard to argue about, I'll just connect everything here, which is going to be easier to monitor.

- I removed the base fee for this simulation, as that alone makes the slot attacks very expensive. Reputation based defense should work well with 0 base fees, which is a network trend as well.